### PR TITLE
Seed on database reset (not in e2e) and redirect when user doesnt exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ node_modules/
 /playwright/.cache/
 /playwright/.auth/
 /.playwright-mcp/*
+
+# Specs
+/specs/

--- a/README.md
+++ b/README.md
@@ -77,17 +77,22 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<anon key from supabase start output>
 supabase stop
 ```
 
-### Seed representatives data
+### Reset the local database and seed representatives
 
-Populate the `representatives` table with current members of Congress from the [congress-legislators](https://github.com/unitedstates/congress-legislators) dataset:
+To reset migrations and populate the `representatives` table with current members of Congress:
 
 ```bash
-NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 \
-  SUPABASE_SERVICE_ROLE_KEY=<secret key from supabase status output> \
-  npx tsx scripts/seed-representatives.ts
+npm run db:reset
 ```
 
-This script is idempotent — it upserts current legislators and marks any previously stored representatives no longer in the dataset as `in_office = false`.
+
+To seed representatives without resetting migrations:
+
+```bash
+npx tsx scripts/seed-representatives.ts
+```
+
+> **Note:** `supabase db reset` alone will not seed representatives — use `npm run db:reset` for local development.
 
 ### Roles and bootstrapping a super admin
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ npm run db:reset
 ```
 
 
-To seed representatives without resetting migrations:
+To seed representatives without resetting migrations, first export your local Supabase credentials, then run the script:
 
 ```bash
+eval "$(npx supabase status -o env)"
 npx tsx scripts/seed-representatives.ts
 ```
 

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -38,14 +38,9 @@ export async function updateSession(request: NextRequest) {
     },
   );
 
-  // Do not run code between createServerClient and
-  // supabase.auth.getClaims(). A simple mistake could make it very hard to debug
-  // issues with users being randomly logged out.
-
-  // IMPORTANT: If you remove getClaims() and you use server-side rendering
-  // with the Supabase client, your users may be randomly logged out.
-  const { data } = await supabase.auth.getClaims();
-  const user = data?.claims;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   if (
     !user &&

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "next start",
     "lint": "eslint .",
     "prepare": "husky",
-    "db:reset": "supabase db reset && eval $(supabase status -o env | grep '^[A-Z_]*=' | sed 's/^/export /') && npx tsx scripts/seed-representatives.ts"
+    "db:reset": "supabase db reset && eval $(npx supabase status -o env | sed 's/^export //' | grep '^[A-Z_]*=' | sed 's/^/export /') && npx tsx scripts/seed-representatives.ts"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs,cjs}": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "prepare": "husky"
+    "prepare": "husky",
+    "db:reset": "supabase db reset && eval $(supabase status -o env | grep '^[A-Z_]*=' | sed 's/^/export /') && npx tsx scripts/seed-representatives.ts"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs,cjs}": [

--- a/scripts/seed-representatives.ts
+++ b/scripts/seed-representatives.ts
@@ -29,12 +29,14 @@ type RepresentativeInsert =
   Database["public"]["Tables"]["representatives"]["Insert"];
 
 async function main() {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const supabaseUrl =
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.API_URL;
+  const serviceRoleKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SERVICE_ROLE_KEY;
 
   if (!supabaseUrl || !serviceRoleKey) {
     console.error(
-      "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY",
+      "Missing Supabase credentials. Run: eval $(supabase status -o env)",
     );
     process.exit(1);
   }

--- a/scripts/seed-representatives.ts
+++ b/scripts/seed-representatives.ts
@@ -30,13 +30,15 @@ type RepresentativeInsert =
 
 async function main() {
   const supabaseUrl =
-    process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.API_URL;
+    process.env.API_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRoleKey =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SERVICE_ROLE_KEY;
+    process.env.SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl || !serviceRoleKey) {
     console.error(
-      "Missing Supabase credentials. Run: eval $(supabase status -o env)",
+      "Missing Supabase credentials.\n" +
+        "  Required: API_URL (or NEXT_PUBLIC_SUPABASE_URL) and SERVICE_ROLE_KEY (or SUPABASE_SERVICE_ROLE_KEY)\n" +
+        '  Run: eval "$(npx supabase status -o env)"',
     );
     process.exit(1);
   }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -60,7 +60,9 @@ schema_paths = []
 [db.seed]
 # If enabled, seeds the database after migrations during a db reset.
 enabled = false
-# Seeding is handled by the Playwright test setup (tests/seed.ts).
+# SQL-only seeding is not used here. For local dev, run `npm run db:reset`
+# which runs `supabase db reset` followed by scripts/seed-representatives.ts
+# (fetches real congress members). E2e test seeding is handled by global-setup.ts.
 sql_paths = []
 
 [db.network_restrictions]


### PR DESCRIPTION
- Adds npm run db:reset script that resets the local database, auto-exports Supabase credentials from supabase status, and seeds real congress members from the [congress-legislators](https://github.com/unitedstates/congress-legislators) dataset — no manual env var setup required
- Updates scripts/seed-representatives.ts to accept both the NEXT_PUBLIC_SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY naming convention and the shorter API_URL/SERVICE_ROLE_KEY names that supabase status -o env actually outputs
- Switches proxy.ts from getClaims() to getUser() so the auth redirect correctly detects users whose accounts no longer exist in the database (e.g. after a local reset), rather than trusting the JWT alone
- Updates README and supabase/config.toml comments to document the new workflow