### PR TITLE
Add meetings tables and schema

### DIFF
--- a/lib/meetings/types.ts
+++ b/lib/meetings/types.ts
@@ -1,0 +1,96 @@
+export type DelegationRole =
+  | "scheduling_lead"
+  | "attendee_talking"
+  | "attendee_listening"
+  | "pih_team_member"
+  | "note_taker";
+
+// ─── List-level types (used by meetings-section and meeting-row) ──────────────
+
+export type MeetingRow = {
+  id: string;
+  meeting_date: string;
+  meeting_time: string | null;
+  representative_id: string;
+  representative_name: string;
+  representative_state: string;
+  representative_district: number | null;
+  representative_party: string;
+  congressional_contact_id: string | null;
+  congressional_contact_name: string;
+  primary_team_id: string | null;
+  primary_team_name: string | null;
+  scheduling_lead_name: string | null;
+  follow_up_date: string | null;
+  champion_score: number | null;
+};
+
+// ─── Detail-level types (used by meeting-detail, delegation-form) ─────────────
+
+export type MeetingLink = {
+  label: string;
+  url: string;
+};
+
+export type DelegationMember = {
+  id: string;
+  user_id: string;
+  display_name: string;
+  role: DelegationRole;
+  team_id: string | null;
+  team_name_snapshot: string | null;
+};
+
+export type MeetingDetail = MeetingRow & {
+  notes: string | null;
+  location: string | null;
+  links: MeetingLink[];
+  delegation_members: DelegationMember[];
+  represented_teams: string[];
+};
+
+// ─── Form input types ─────────────────────────────────────────────────────────
+
+export type MeetingFormValues = {
+  meeting_date: string;
+  meeting_time: string | null;
+  representative_id: string;
+  congressional_contact_id: string | null;
+  primary_team_id: string | null;
+  notes: string;
+  location: string;
+  follow_up_date: string | null;
+  champion_score: number | null;
+};
+
+export type LinkFormEntry = {
+  label: string;
+  url: string;
+};
+
+export type DelegationFormEntry = {
+  user_id: string;
+  role: DelegationRole;
+  team_id: string | null;
+};
+
+// ─── Filter types (used by meetings-filters) ──────────────────────────────────
+
+export type MeetingFilters = {
+  states: string[];
+  districts: string[];
+  parties: string[];
+};
+
+// ─── Profile search result (used by delegation-form user search) ──────────────
+
+export type ProfileTeam = {
+  team_id: string;
+  team_name: string;
+};
+
+export type ProfileSearchResult = {
+  user_id: string;
+  display_name: string;
+  teams: ProfileTeam[];
+};

--- a/lib/meetings/types.ts
+++ b/lib/meetings/types.ts
@@ -1,9 +1,6 @@
-export type DelegationRole =
-  | "scheduling_lead"
-  | "attendee_talking"
-  | "attendee_listening"
-  | "pih_team_member"
-  | "note_taker";
+import type { Database } from "@/lib/supabase/database.types";
+
+export type DelegationRole = Database["public"]["Enums"]["delegation_role"];
 
 // ─── List-level types (used by meetings-section and meeting-row) ──────────────
 
@@ -57,16 +54,13 @@ export type MeetingFormValues = {
   representative_id: string;
   congressional_contact_id: string | null;
   primary_team_id: string | null;
-  notes: string;
-  location: string;
+  notes: string | null;
+  location: string | null;
   follow_up_date: string | null;
   champion_score: number | null;
 };
 
-export type LinkFormEntry = {
-  label: string;
-  url: string;
-};
+export type LinkFormEntry = MeetingLink;
 
 export type DelegationFormEntry = {
   user_id: string;

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -34,38 +34,54 @@ export type Database = {
   };
   public: {
     Tables: {
-      team_memberships: {
+      meeting_delegation_members: {
         Row: {
           created_at: string;
+          id: string;
+          meeting_id: string;
           org_id: string;
-          role: string;
-          team_id: string;
+          role: Database["public"]["Enums"]["delegation_role"];
+          team_id: string | null;
+          team_name_snapshot: string | null;
           user_id: string;
         };
         Insert: {
           created_at?: string;
+          id?: string;
+          meeting_id: string;
           org_id: string;
-          role: string;
-          team_id: string;
+          role: Database["public"]["Enums"]["delegation_role"];
+          team_id?: string | null;
+          team_name_snapshot?: string | null;
           user_id: string;
         };
         Update: {
           created_at?: string;
+          id?: string;
+          meeting_id?: string;
           org_id?: string;
-          role?: string;
-          team_id?: string;
+          role?: Database["public"]["Enums"]["delegation_role"];
+          team_id?: string | null;
+          team_name_snapshot?: string | null;
           user_id?: string;
         };
         Relationships: [
           {
-            foreignKeyName: "team_memberships_team_id_fkey";
+            foreignKeyName: "meeting_delegation_members_meeting_id_fkey";
+            columns: ["meeting_id"];
+            isOneToOne: false;
+            referencedRelation: "meetings";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "meeting_delegation_members_team_id_fkey";
             columns: ["team_id"];
             isOneToOne: false;
             referencedRelation: "teams";
             referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "team_memberships_user_id_profiles_fkey";
+            foreignKeyName: "meeting_delegation_members_user_id_fkey";
             columns: ["user_id"];
             isOneToOne: false;
             referencedRelation: "profiles";
@@ -73,47 +89,78 @@ export type Database = {
           },
         ];
       };
-      teams: {
+      meetings: {
         Row: {
-          congressional_districts: string[];
+          champion_score: number | null;
+          congressional_contact_id: string | null;
           created_at: string;
-          description: string | null;
-          founded_date: string | null;
+          created_by: string;
+          follow_up_date: string | null;
           id: string;
-          name: string;
+          links: Json;
+          location: string | null;
+          meeting_date: string;
+          meeting_time: string | null;
+          notes: string | null;
           org_id: string;
-          slug: string;
-          state: string;
-          type: string;
-          updated_at: string;
+          primary_team_id: string | null;
+          representative_id: string;
         };
         Insert: {
-          congressional_districts?: string[];
+          champion_score?: number | null;
+          congressional_contact_id?: string | null;
           created_at?: string;
-          description?: string | null;
-          founded_date?: string | null;
+          created_by: string;
+          follow_up_date?: string | null;
           id?: string;
-          name: string;
+          links?: Json;
+          location?: string | null;
+          meeting_date: string;
+          meeting_time?: string | null;
+          notes?: string | null;
           org_id: string;
-          slug?: string;
-          state: string;
-          type: string;
-          updated_at?: string;
+          primary_team_id?: string | null;
+          representative_id: string;
         };
         Update: {
-          congressional_districts?: string[];
+          champion_score?: number | null;
+          congressional_contact_id?: string | null;
           created_at?: string;
-          description?: string | null;
-          founded_date?: string | null;
+          created_by?: string;
+          follow_up_date?: string | null;
           id?: string;
-          name?: string;
+          links?: Json;
+          location?: string | null;
+          meeting_date?: string;
+          meeting_time?: string | null;
+          notes?: string | null;
           org_id?: string;
-          slug?: string;
-          state?: string;
-          type?: string;
-          updated_at?: string;
+          primary_team_id?: string | null;
+          representative_id?: string;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: "meetings_congressional_contact_id_fkey";
+            columns: ["congressional_contact_id"];
+            isOneToOne: false;
+            referencedRelation: "staffers";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "meetings_primary_team_id_fkey";
+            columns: ["primary_team_id"];
+            isOneToOne: false;
+            referencedRelation: "teams";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "meetings_representative_id_fkey";
+            columns: ["representative_id"];
+            isOneToOne: false;
+            referencedRelation: "representatives";
+            referencedColumns: ["id"];
+          },
+        ];
       };
       profiles: {
         Row: {
@@ -290,6 +337,87 @@ export type Database = {
           },
         ];
       };
+      team_memberships: {
+        Row: {
+          created_at: string;
+          org_id: string;
+          role: string;
+          team_id: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          org_id: string;
+          role: string;
+          team_id: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          org_id?: string;
+          role?: string;
+          team_id?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "team_memberships_team_id_fkey";
+            columns: ["team_id"];
+            isOneToOne: false;
+            referencedRelation: "teams";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "team_memberships_user_id_profiles_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["user_id"];
+          },
+        ];
+      };
+      teams: {
+        Row: {
+          congressional_districts: string[];
+          created_at: string;
+          description: string | null;
+          founded_date: string | null;
+          id: string;
+          name: string;
+          org_id: string;
+          slug: string;
+          state: string;
+          type: string;
+          updated_at: string;
+        };
+        Insert: {
+          congressional_districts?: string[];
+          created_at?: string;
+          description?: string | null;
+          founded_date?: string | null;
+          id?: string;
+          name: string;
+          org_id: string;
+          slug: string;
+          state: string;
+          type: string;
+          updated_at?: string;
+        };
+        Update: {
+          congressional_districts?: string[];
+          created_at?: string;
+          description?: string | null;
+          founded_date?: string | null;
+          id?: string;
+          name?: string;
+          org_id?: string;
+          slug?: string;
+          state?: string;
+          type?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       user_role: {
         Row: {
           org_id: string | null;
@@ -315,10 +443,10 @@ export type Database = {
     Functions: {
       change_member_role: {
         Args: {
+          p_new_role: string;
+          p_old_role: string;
           p_team_id: string;
           p_user_id: string;
-          p_old_role: string;
-          p_new_role: string;
         };
         Returns: undefined;
       };
@@ -328,6 +456,12 @@ export type Database = {
     };
     Enums: {
       app_role: "member" | "org_admin" | "super_admin";
+      delegation_role:
+        | "scheduling_lead"
+        | "attendee_talking"
+        | "attendee_listening"
+        | "pih_team_member"
+        | "note_taker";
     };
     CompositeTypes: {
       [_ in never]: never;
@@ -462,6 +596,13 @@ export const Constants = {
   public: {
     Enums: {
       app_role: ["member", "org_admin", "super_admin"],
+      delegation_role: [
+        "scheduling_lead",
+        "attendee_talking",
+        "attendee_listening",
+        "pih_team_member",
+        "note_taker",
+      ],
     },
   },
 } as const;

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -105,6 +105,7 @@ export type Database = {
           org_id: string;
           primary_team_id: string | null;
           representative_id: string;
+          updated_at: string;
         };
         Insert: {
           champion_score?: number | null;
@@ -121,6 +122,7 @@ export type Database = {
           org_id: string;
           primary_team_id?: string | null;
           representative_id: string;
+          updated_at?: string;
         };
         Update: {
           champion_score?: number | null;
@@ -137,6 +139,7 @@ export type Database = {
           org_id?: string;
           primary_team_id?: string | null;
           representative_id?: string;
+          updated_at?: string;
         };
         Relationships: [
           {

--- a/supabase/migrations/20260525000000_create_meetings.sql
+++ b/supabase/migrations/20260525000000_create_meetings.sql
@@ -57,6 +57,6 @@ create policy "org members update own-org meetings"
   using (public.is_in_org(org_id) or public.is_super_admin())
   with check (public.is_in_org(org_id) or public.is_super_admin());
 
-create policy "org members delete own-org meetings"
+create policy "org admins delete own-org meetings"
   on public.meetings for delete to authenticated
-  using (public.is_in_org(org_id) or public.is_super_admin());
+  using (public.is_org_admin_for(org_id) or public.is_super_admin());

--- a/supabase/migrations/20260525000000_create_meetings.sql
+++ b/supabase/migrations/20260525000000_create_meetings.sql
@@ -1,0 +1,40 @@
+create table public.meetings (
+  id                       uuid        primary key default gen_random_uuid(),
+  org_id                   text        not null,
+  meeting_date             date        not null,
+  meeting_time             text,
+  representative_id        uuid        not null references public.representatives(id),
+  congressional_contact_id uuid        references public.staffers(id) on delete set null,
+  primary_team_id          uuid        references public.teams(id) on delete set null,
+  notes                    text        check (char_length(notes) <= 255),
+  location                 text,
+  follow_up_date           date,
+  champion_score           integer     check (champion_score between 0 and 5),
+  links                    jsonb       not null default '[]',
+  created_at               timestamptz not null default now(),
+  created_by               uuid        not null references auth.users(id)
+);
+
+create index idx_meetings_org_date on public.meetings (org_id, meeting_date desc);
+
+grant select, insert, update, delete on public.meetings to authenticated;
+grant select, insert, update, delete on public.meetings to service_role;
+
+alter table public.meetings enable row level security;
+
+create policy "org members read own-org meetings"
+  on public.meetings for select to authenticated
+  using (public.is_in_org(org_id) or public.is_super_admin());
+
+create policy "org members insert own-org meetings"
+  on public.meetings for insert to authenticated
+  with check (public.is_in_org(org_id) or public.is_super_admin());
+
+create policy "org members update own-org meetings"
+  on public.meetings for update to authenticated
+  using (public.is_in_org(org_id) or public.is_super_admin())
+  with check (public.is_in_org(org_id) or public.is_super_admin());
+
+create policy "org members delete own-org meetings"
+  on public.meetings for delete to authenticated
+  using (public.is_in_org(org_id) or public.is_super_admin());

--- a/supabase/migrations/20260525000000_create_meetings.sql
+++ b/supabase/migrations/20260525000000_create_meetings.sql
@@ -10,10 +10,15 @@ create table public.meetings (
   location                 text,
   follow_up_date           date,
   champion_score           integer     check (champion_score between 0 and 5),
-  links                    jsonb       not null default '[]',
+  links                    jsonb       not null default '[]'::jsonb,
   created_at               timestamptz not null default now(),
+  updated_at               timestamptz not null default now(),
   created_by               uuid        not null references auth.users(id)
 );
+
+create trigger meetings_updated_at
+  before update on public.meetings
+  for each row execute function public.handle_updated_at();
 
 create index idx_meetings_org_date on public.meetings (org_id, meeting_date desc);
 
@@ -28,7 +33,24 @@ create policy "org members read own-org meetings"
 
 create policy "org members insert own-org meetings"
   on public.meetings for insert to authenticated
-  with check (public.is_in_org(org_id) or public.is_super_admin());
+  with check (
+    (public.is_in_org(org_id) or public.is_super_admin())
+    and created_by = auth.uid()
+  );
+
+create or replace function public.meetings_lock_created_by()
+  returns trigger
+  language plpgsql
+as $$
+begin
+  new.created_by := old.created_by;
+  return new;
+end;
+$$;
+
+create trigger meetings_lock_created_by
+  before update on public.meetings
+  for each row execute function public.meetings_lock_created_by();
 
 create policy "org members update own-org meetings"
   on public.meetings for update to authenticated

--- a/supabase/migrations/20260525000001_create_meeting_delegation_members.sql
+++ b/supabase/migrations/20260525000001_create_meeting_delegation_members.sql
@@ -10,7 +10,7 @@ create table public.meeting_delegation_members (
   id                 uuid                   primary key default gen_random_uuid(),
   meeting_id         uuid                   not null references public.meetings(id) on delete cascade,
   org_id             text                   not null,
-  user_id            uuid                   not null references public.profiles(user_id),
+  user_id            uuid                   not null references public.profiles(user_id) on delete cascade,
   role               public.delegation_role not null,
   team_id            uuid                   references public.teams(id) on delete set null,
   team_name_snapshot text,

--- a/supabase/migrations/20260525000001_create_meeting_delegation_members.sql
+++ b/supabase/migrations/20260525000001_create_meeting_delegation_members.sql
@@ -1,0 +1,44 @@
+create type public.delegation_role as enum (
+  'scheduling_lead',
+  'attendee_talking',
+  'attendee_listening',
+  'pih_team_member',
+  'note_taker'
+);
+
+create table public.meeting_delegation_members (
+  id                 uuid                   primary key default gen_random_uuid(),
+  meeting_id         uuid                   not null references public.meetings(id) on delete cascade,
+  org_id             text                   not null,
+  user_id            uuid                   not null references public.profiles(user_id),
+  role               public.delegation_role not null,
+  team_id            uuid                   references public.teams(id) on delete set null,
+  team_name_snapshot text,
+  created_at         timestamptz            not null default now(),
+  unique (meeting_id, user_id)
+);
+
+create index idx_meeting_delegation_members_meeting on public.meeting_delegation_members (meeting_id);
+create index idx_meeting_delegation_members_user    on public.meeting_delegation_members (user_id);
+
+grant select, insert, update, delete on public.meeting_delegation_members to authenticated;
+grant select, insert, update, delete on public.meeting_delegation_members to service_role;
+
+alter table public.meeting_delegation_members enable row level security;
+
+create policy "org members read own-org delegation members"
+  on public.meeting_delegation_members for select to authenticated
+  using (public.is_in_org(org_id) or public.is_super_admin());
+
+create policy "org members insert own-org delegation members"
+  on public.meeting_delegation_members for insert to authenticated
+  with check (public.is_in_org(org_id) or public.is_super_admin());
+
+create policy "org members update own-org delegation members"
+  on public.meeting_delegation_members for update to authenticated
+  using (public.is_in_org(org_id) or public.is_super_admin())
+  with check (public.is_in_org(org_id) or public.is_super_admin());
+
+create policy "org members delete own-org delegation members"
+  on public.meeting_delegation_members for delete to authenticated
+  using (public.is_in_org(org_id) or public.is_super_admin());


### PR DESCRIPTION
This creates the tables and schema for the upcoming meetings page. It includes all the information necessary for a meeting.

Two new tables:
meetings - information about the meeting
meeting_delegation_members - maps meeting to delegation members and the team associated.