### PR TITLE
Creating improved db scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ supabase init
 2. Start the local Supabase stack (requires Docker):
 
 ```bash
-supabase start
+npm run supabase:start
 ```
 
 This starts a local Postgres database, Auth server, and API. Once running, the CLI prints connection details — copy the `API URL` and `anon key` values.
@@ -77,23 +77,33 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<anon key from supabase start output>
 supabase stop
 ```
 
-### Reset the local database and seed representatives
+### Database commands
 
-To reset migrations and populate the `representatives` table with current members of Congress:
+| Command | When to use |
+|---|---|
+| `npm run supabase:start` | Start Supabase after a restart — **preserves all data** |
+| `npm run db:migrate` | Apply new migration files to your existing local DB — **preserves all data** |
+| `npm run db:reset` | Wipe everything and re-seed from scratch — **destroys all local data** |
+
+**In production** migrations are applied incrementally by the CI/CD pipeline — no data is ever dropped. `db:reset` is a local-only development tool and is never used in production.
+
+#### When you pull new migrations from main
+
+Just run:
+
+```bash
+npm run db:migrate
+```
+
+This applies only the new migration files that haven't run yet. Your account and all existing data are preserved.
+
+#### First-time setup or intentional clean slate
 
 ```bash
 npm run db:reset
 ```
 
-
-To seed representatives without resetting migrations, first export your local Supabase credentials, then run the script:
-
-```bash
-eval "$(npx supabase status -o env)"
-npx tsx scripts/seed-representatives.ts
-```
-
-> **Note:** `supabase db reset` alone will not seed representatives — use `npm run db:reset` for local development.
+Wipes the local database, re-applies all migrations from scratch, and re-seeds the `representatives` table with current members of Congress.
 
 ### Roles and bootstrapping a super admin
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "start": "next start",
     "lint": "eslint .",
     "prepare": "husky",
-    "db:reset": "supabase db reset && eval $(npx supabase status -o env | sed 's/^export //' | grep '^[A-Z_]*=' | sed 's/^/export /') && npx tsx scripts/seed-representatives.ts"
+    "db:migrate": "supabase migration up --local",
+    "db:reset": "node scripts/db-reset.mjs",
+    "supabase:start": "node scripts/supabase-start.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs,cjs}": [

--- a/scripts/db-reset.mjs
+++ b/scripts/db-reset.mjs
@@ -1,0 +1,39 @@
+/**
+ * Cross-platform replacement for the bash-only db:reset npm script.
+ * Runs `supabase db reset`, reads the local credentials via
+ * `supabase status -o env`, then seeds representatives — without relying
+ * on `eval`, `sed`, or any POSIX shell syntax.
+ *
+ * Use this when you need to wipe the database and start fresh (e.g. after
+ * adding new migrations). Do NOT run this just to restart Supabase — use
+ * `npm run supabase:start` instead, which preserves all data.
+ */
+import { execSync, spawnSync } from "child_process";
+
+// 1. Wipe and re-apply all migrations.
+execSync("supabase db reset", { stdio: "inherit" });
+
+// 2. Read the local Supabase credentials from `supabase status -o env`.
+//    Output format: KEY="value" (one per line, may include warning lines).
+let statusOutput;
+try {
+  statusOutput = execSync("supabase status -o env", { encoding: "utf8" });
+} catch (err) {
+  // stderr warnings can cause a non-zero exit code; grab stdout anyway.
+  statusOutput = err.stdout ?? "";
+}
+
+const env = { ...process.env };
+for (const line of statusOutput.split("\n")) {
+  const match = line.match(/^(\w+)="(.+)"$/);
+  if (match) env[match[1]] = match[2];
+}
+
+// 3. Seed representatives (uses API_URL + SERVICE_ROLE_KEY from env above).
+const result = spawnSync(
+  process.platform === "win32" ? "npx.cmd" : "npx",
+  ["tsx", "scripts/seed-representatives.ts"],
+  { stdio: "inherit", env },
+);
+
+process.exit(result.status ?? 0);

--- a/scripts/supabase-start.mjs
+++ b/scripts/supabase-start.mjs
@@ -1,0 +1,17 @@
+import { execSync } from "child_process";
+
+// Remove the vector container if it is lingering from a previous session.
+// This happens on Windows when Docker isn't shut down cleanly — the container
+// name stays reserved even though it's stopped, and `supabase start` refuses
+// to create a new one with the same name. Removing the container is safe: it
+// does NOT touch the Docker volume, so all database data is preserved.
+try {
+  execSync("docker rm -f supabase_vector_pih-advocacy-engage", {
+    stdio: "pipe",
+  });
+  console.log("Removed stale supabase_vector container.");
+} catch {
+  // Container wasn't there — nothing to do.
+}
+
+execSync("supabase start", { stdio: "inherit" });


### PR DESCRIPTION
Supabase is incredibly finicky on Windows at least, so I've created improved scripts to start the database as well as migrate (without resetting) and reset the database.

### Database commands

| Command | When to use |
|---|---|
| `npm run supabase:start` | Start Supabase after a restart — **preserves all data** |
| `npm run db:migrate` | Apply new migration files to your existing local DB — **preserves all data** |
| `npm run db:reset` | Wipe everything and re-seed from scratch — **destroys all local data** |

**In production** migrations are applied incrementally by the CI/CD pipeline — no data is ever dropped. `db:reset` is a local-only development tool and is never used in production.