### PR TITLE
Add meeting_timezone column and convert meeting_time to time type

### DIFF
--- a/supabase/migrations/20260531000000_add_meeting_timezone.sql
+++ b/supabase/migrations/20260531000000_add_meeting_timezone.sql
@@ -1,0 +1,5 @@
+alter table public.meetings
+  add column meeting_timezone text not null default 'America/New_York';
+
+alter table public.meetings
+  alter column meeting_time type time using meeting_time::time;


### PR DESCRIPTION
## Summary

- Adds `meeting_timezone text not null default 'America/New_York'` to the `meetings` table so meeting times are unambiguous across timezones
- Converts `meeting_time` from `text` to PostgreSQL `time` type so values are validated at the DB level and stored consistently (e.g. `14:00:00` rather than arbitrary strings)
