### PR TITLE
US3a — expandable meeting rows with read-only detail panel

### DIFF
--- a/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
@@ -3,70 +3,33 @@
 exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 1`] = `
 <DocumentFragment>
   <div
-    class="relative border-t p-6"
+    class="p-4"
   >
-    <button
-      aria-label="Edit meeting"
-      class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-9 absolute right-4 top-4 h-8 w-8"
-      data-size="icon"
-      data-slot="tooltip-trigger"
-      data-state="closed"
-      data-variant="outline"
-    >
-      <svg
-        aria-hidden="true"
-        class="lucide lucide-pencil h-3.5 w-3.5"
-        fill="none"
-        height="24"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
-        />
-        <path
-          d="m15 5 4 4"
-        />
-      </svg>
-    </button>
     <div
       class="grid gap-6 @[600px]:grid-cols-2"
     >
       <div
         class="flex flex-col gap-4"
       >
-        <div>
-          <p
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-          >
-            Time
-          </p>
-          <p
-            class="mt-1 text-sm"
-          >
-            9:00 AM EDT
-          </p>
+        <div
+          class="flex gap-6"
+        >
+          <div>
+            <p
+              class="font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Champion Level
+            </p>
+            <p
+              class="mt-1 text-sm"
+            >
+              4 – Advocate
+            </p>
+          </div>
         </div>
         <div>
           <p
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-          >
-            Location
-          </p>
-          <p
-            class="mt-1 text-sm"
-          >
-            Virtual
-          </p>
-        </div>
-        <div>
-          <p
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            class="font-semibold uppercase tracking-wide text-muted-foreground"
           >
             Notes
           </p>
@@ -82,7 +45,7 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
         </div>
         <div>
           <p
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            class="font-semibold uppercase tracking-wide text-muted-foreground"
           >
             Links
           </p>
@@ -130,7 +93,31 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
       >
         <div>
           <p
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            class="font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Time
+          </p>
+          <p
+            class="mt-1 text-sm"
+          >
+            9:00 AM EDT
+          </p>
+        </div>
+        <div>
+          <p
+            class="font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Location
+          </p>
+          <p
+            class="mt-1 text-sm"
+          >
+            Virtual
+          </p>
+        </div>
+        <div>
+          <p
+            class="font-semibold uppercase tracking-wide text-muted-foreground"
           >
             Delegation
           </p>
@@ -141,7 +128,7 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
               class="flex flex-col gap-0.5"
             >
               <span
-                class="text-xs text-muted-foreground"
+                class="text-sm text-muted-foreground"
               >
                 Scheduling Lead
               </span>
@@ -175,7 +162,7 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
               class="flex flex-col gap-0.5"
             >
               <span
-                class="text-xs text-muted-foreground"
+                class="text-sm text-muted-foreground"
               >
                 PIH Team Member
               </span>
@@ -207,17 +194,37 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
             </div>
           </div>
         </div>
-        <div>
-          <p
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+        <div
+          class="mt-auto pt-2"
+        >
+          <button
+            class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 h-9 px-4 py-2 has-[>svg]:px-3"
+            data-size="default"
+            data-slot="button"
+            data-variant="outline"
           >
-            Champion Level
-          </p>
-          <p
-            class="mt-1 text-sm"
-          >
-            4 – Advocate
-          </p>
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-pencil h-3.5 w-3.5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
+              />
+              <path
+                d="m15 5 4 4"
+              />
+            </svg>
+            Edit Meeting
+          </button>
         </div>
       </div>
     </div>
@@ -228,37 +235,8 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
 exports[`MeetingDetailView — snapshots > matches snapshot with minimal fields (no optional data) 1`] = `
 <DocumentFragment>
   <div
-    class="relative border-t p-6"
+    class="p-4"
   >
-    <button
-      aria-label="Edit meeting"
-      class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-9 absolute right-4 top-4 h-8 w-8"
-      data-size="icon"
-      data-slot="tooltip-trigger"
-      data-state="closed"
-      data-variant="outline"
-    >
-      <svg
-        aria-hidden="true"
-        class="lucide lucide-pencil h-3.5 w-3.5"
-        fill="none"
-        height="24"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
-        />
-        <path
-          d="m15 5 4 4"
-        />
-      </svg>
-    </button>
     <div
       class="grid gap-6 @[600px]:grid-cols-2"
     >
@@ -270,7 +248,7 @@ exports[`MeetingDetailView — snapshots > matches snapshot with minimal fields 
       >
         <div>
           <p
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            class="font-semibold uppercase tracking-wide text-muted-foreground"
           >
             Delegation
           </p>
@@ -279,6 +257,38 @@ exports[`MeetingDetailView — snapshots > matches snapshot with minimal fields 
           >
             None
           </p>
+        </div>
+        <div
+          class="mt-auto pt-2"
+        >
+          <button
+            class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 h-9 px-4 py-2 has-[>svg]:px-3"
+            data-size="default"
+            data-slot="button"
+            data-variant="outline"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-pencil h-3.5 w-3.5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
+              />
+              <path
+                d="m15 5 4 4"
+              />
+            </svg>
+            Edit Meeting
+          </button>
         </div>
       </div>
     </div>

--- a/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
               >
                 <span
                   aria-hidden="true"
-                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
+                  class="flex shrink-0 items-center justify-center rounded-full text-xs font-semibold h-7 w-7 bg-muted text-foreground"
                 >
                   AS
                 </span>
@@ -171,7 +171,7 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
               >
                 <span
                   aria-hidden="true"
-                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
+                  class="flex shrink-0 items-center justify-center rounded-full text-xs font-semibold h-7 w-7 bg-muted text-foreground"
                 >
                   BJ
                 </span>

--- a/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
               >
                 <span
                   aria-hidden="true"
-                  class="flex shrink-0 items-center justify-center rounded-full text-xs font-semibold h-7 w-7 bg-muted text-foreground"
+                  class="flex shrink-0 items-center justify-center rounded-full text-xs font-semibold h-8 w-8 bg-muted text-foreground"
                 >
                   AS
                 </span>
@@ -171,7 +171,7 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
               >
                 <span
                   aria-hidden="true"
-                  class="flex shrink-0 items-center justify-center rounded-full text-xs font-semibold h-7 w-7 bg-muted text-foreground"
+                  class="flex shrink-0 items-center justify-center rounded-full text-xs font-semibold h-8 w-8 bg-muted text-foreground"
                 >
                   BJ
                 </span>

--- a/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 1`] = `
 <DocumentFragment>
   <div
-    class="border-t p-6"
+    class="border-t p-6 @container"
   >
     <div
-      class="grid gap-6 sm:grid-cols-2"
+      class="grid gap-6 @[600px]:grid-cols-2"
     >
       <div
         class="flex flex-col gap-4"
@@ -219,10 +219,10 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
 exports[`MeetingDetailView — snapshots > matches snapshot with minimal fields (no optional data) 1`] = `
 <DocumentFragment>
   <div
-    class="border-t p-6"
+    class="border-t p-6 @container"
   >
     <div
-      class="grid gap-6 sm:grid-cols-2"
+      class="grid gap-6 @[600px]:grid-cols-2"
     >
       <div
         class="flex flex-col gap-4"

--- a/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
             <p
               class="mt-1 text-sm"
             >
-              4 – Advocate
+              4 – Leader
             </p>
           </div>
         </div>

--- a/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
@@ -3,8 +3,37 @@
 exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 1`] = `
 <DocumentFragment>
   <div
-    class="border-t p-6 @container"
+    class="relative border-t p-6"
   >
+    <button
+      aria-label="Edit meeting"
+      class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-9 absolute right-4 top-4 h-8 w-8"
+      data-size="icon"
+      data-slot="tooltip-trigger"
+      data-state="closed"
+      data-variant="outline"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-pencil h-3.5 w-3.5"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
+        />
+        <path
+          d="m15 5 4 4"
+        />
+      </svg>
+    </button>
     <div
       class="grid gap-6 @[600px]:grid-cols-2"
     >
@@ -105,66 +134,78 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
           >
             Delegation
           </p>
-          <ul
-            class="mt-1 flex flex-col gap-2"
+          <div
+            class="mt-2 flex flex-col gap-3"
           >
-            <li
-              class="flex items-center gap-2"
+            <div
+              class="flex flex-col gap-0.5"
             >
-              <span
-                aria-hidden="true"
-                class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
-              >
-                AS
-              </span>
-              <span
-                class="text-sm"
-              >
-                Alice Smith
-              </span>
               <span
                 class="text-xs text-muted-foreground"
               >
-                — Scheduling Lead
+                Scheduling Lead
               </span>
-            </li>
-            <li
-              class="flex items-center gap-2"
+              <span
+                class="flex items-center gap-2"
+              >
+                <span
+                  aria-hidden="true"
+                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
+                >
+                  AS
+                </span>
+                <span
+                  class="min-w-0 flex-1"
+                >
+                  <span
+                    class="text-sm font-medium"
+                  >
+                    Alice Smith
+                  </span>
+                  <a
+                    class="ml-1.5 text-xs text-muted-foreground underline-offset-4 hover:underline"
+                    href="mailto:alice@example.com"
+                  >
+                    alice@example.com
+                  </a>
+                </span>
+              </span>
+            </div>
+            <div
+              class="flex flex-col gap-0.5"
             >
-              <span
-                aria-hidden="true"
-                class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
-              >
-                BJ
-              </span>
-              <span
-                class="text-sm"
-              >
-                Bob Jones
-              </span>
               <span
                 class="text-xs text-muted-foreground"
               >
-                — PIH Team Member
+                PIH Team Member
               </span>
-            </li>
-          </ul>
-        </div>
-        <div>
-          <p
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-          >
-            PIH Team Member
-          </p>
-          <ul
-            class="mt-1 flex flex-col gap-1"
-          >
-            <li
-              class="text-sm"
-            >
-              Bob Jones
-            </li>
-          </ul>
+              <span
+                class="flex items-center gap-2"
+              >
+                <span
+                  aria-hidden="true"
+                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
+                >
+                  BJ
+                </span>
+                <span
+                  class="min-w-0 flex-1"
+                >
+                  <span
+                    class="text-sm font-medium"
+                  >
+                    Bob Jones
+                  </span>
+                  <a
+                    class="ml-1.5 text-xs text-muted-foreground underline-offset-4 hover:underline"
+                    href="mailto:bob@example.com"
+                  >
+                    bob@example.com
+                  </a>
+                </span>
+              </span>
+            </div>
+          </div>
         </div>
         <div>
           <p
@@ -180,38 +221,6 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
         </div>
       </div>
     </div>
-    <div
-      class="mt-6"
-    >
-      <button
-        class="inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 h-8 gap-1.5 rounded-md px-3 text-xs has-[>svg]:px-2.5"
-        data-size="sm"
-        data-slot="button"
-        data-variant="outline"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-pencil mr-1.5 h-3.5 w-3.5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
-          />
-          <path
-            d="m15 5 4 4"
-          />
-        </svg>
-        Edit Meeting
-      </button>
-    </div>
   </div>
 </DocumentFragment>
 `;
@@ -219,8 +228,37 @@ exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 
 exports[`MeetingDetailView — snapshots > matches snapshot with minimal fields (no optional data) 1`] = `
 <DocumentFragment>
   <div
-    class="border-t p-6 @container"
+    class="relative border-t p-6"
   >
+    <button
+      aria-label="Edit meeting"
+      class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-9 absolute right-4 top-4 h-8 w-8"
+      data-size="icon"
+      data-slot="tooltip-trigger"
+      data-state="closed"
+      data-variant="outline"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-pencil h-3.5 w-3.5"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
+        />
+        <path
+          d="m15 5 4 4"
+        />
+      </svg>
+    </button>
     <div
       class="grid gap-6 @[600px]:grid-cols-2"
     >
@@ -243,38 +281,6 @@ exports[`MeetingDetailView — snapshots > matches snapshot with minimal fields 
           </p>
         </div>
       </div>
-    </div>
-    <div
-      class="mt-6"
-    >
-      <button
-        class="inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 h-8 gap-1.5 rounded-md px-3 text-xs has-[>svg]:px-2.5"
-        data-size="sm"
-        data-slot="button"
-        data-variant="outline"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-pencil mr-1.5 h-3.5 w-3.5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
-          />
-          <path
-            d="m15 5 4 4"
-          />
-        </svg>
-        Edit Meeting
-      </button>
     </div>
   </div>
 </DocumentFragment>

--- a/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meeting-detail-view.test.tsx.snap
@@ -1,0 +1,281 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MeetingDetailView — snapshots > matches snapshot with all fields set 1`] = `
+<DocumentFragment>
+  <div
+    class="border-t p-6"
+  >
+    <div
+      class="grid gap-6 sm:grid-cols-2"
+    >
+      <div
+        class="flex flex-col gap-4"
+      >
+        <div>
+          <p
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Time
+          </p>
+          <p
+            class="mt-1 text-sm"
+          >
+            9:00 AM EDT
+          </p>
+        </div>
+        <div>
+          <p
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Location
+          </p>
+          <p
+            class="mt-1 text-sm"
+          >
+            Virtual
+          </p>
+        </div>
+        <div>
+          <p
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Notes
+          </p>
+          <div
+            class="mt-1 border-l-4 border-muted pl-3"
+          >
+            <p
+              class="text-sm"
+            >
+              Brief discussion on policy.
+            </p>
+          </div>
+        </div>
+        <div>
+          <p
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Links
+          </p>
+          <ul
+            class="mt-1 flex flex-col gap-1"
+          >
+            <li>
+              <a
+                class="inline-flex items-center gap-1 text-sm text-primary-dark underline-offset-4 hover:underline"
+                href="https://example.com/deck"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="lucide lucide-external-link h-3 w-3 shrink-0"
+                  fill="none"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 3h6v6"
+                  />
+                  <path
+                    d="M10 14 21 3"
+                  />
+                  <path
+                    d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+                  />
+                </svg>
+                Deck
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        class="flex flex-col gap-4"
+      >
+        <div>
+          <p
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Delegation
+          </p>
+          <ul
+            class="mt-1 flex flex-col gap-2"
+          >
+            <li
+              class="flex items-center gap-2"
+            >
+              <span
+                aria-hidden="true"
+                class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
+              >
+                AS
+              </span>
+              <span
+                class="text-sm"
+              >
+                Alice Smith
+              </span>
+              <span
+                class="text-xs text-muted-foreground"
+              >
+                — Scheduling Lead
+              </span>
+            </li>
+            <li
+              class="flex items-center gap-2"
+            >
+              <span
+                aria-hidden="true"
+                class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
+              >
+                BJ
+              </span>
+              <span
+                class="text-sm"
+              >
+                Bob Jones
+              </span>
+              <span
+                class="text-xs text-muted-foreground"
+              >
+                — PIH Team Member
+              </span>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <p
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            PIH Team Member
+          </p>
+          <ul
+            class="mt-1 flex flex-col gap-1"
+          >
+            <li
+              class="text-sm"
+            >
+              Bob Jones
+            </li>
+          </ul>
+        </div>
+        <div>
+          <p
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Champion Level
+          </p>
+          <p
+            class="mt-1 text-sm"
+          >
+            4 – Advocate
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="mt-6"
+    >
+      <button
+        class="inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 h-8 gap-1.5 rounded-md px-3 text-xs has-[>svg]:px-2.5"
+        data-size="sm"
+        data-slot="button"
+        data-variant="outline"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-pencil mr-1.5 h-3.5 w-3.5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
+          />
+          <path
+            d="m15 5 4 4"
+          />
+        </svg>
+        Edit Meeting
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`MeetingDetailView — snapshots > matches snapshot with minimal fields (no optional data) 1`] = `
+<DocumentFragment>
+  <div
+    class="border-t p-6"
+  >
+    <div
+      class="grid gap-6 sm:grid-cols-2"
+    >
+      <div
+        class="flex flex-col gap-4"
+      />
+      <div
+        class="flex flex-col gap-4"
+      >
+        <div>
+          <p
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            Delegation
+          </p>
+          <p
+            class="mt-1 text-sm text-muted-foreground"
+          >
+            None
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="mt-6"
+    >
+      <button
+        class="inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 h-8 gap-1.5 rounded-md px-3 text-xs has-[>svg]:px-2.5"
+        data-size="sm"
+        data-slot="button"
+        data-variant="outline"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-pencil mr-1.5 h-3.5 w-3.5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
+          />
+          <path
+            d="m15 5 4 4"
+          />
+        </svg>
+        Edit Meeting
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
           data-slot="table-cell"
         >
           <button
+            aria-controls="meeting-detail-id-1"
             aria-expanded="false"
             aria-label="Expand meeting with Jane Rep"
             class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 size-9"
@@ -136,6 +137,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
           data-slot="table-cell"
         >
           <button
+            aria-controls="meeting-detail-id-1"
             aria-expanded="false"
             aria-label="Expand meeting with Jane Rep"
             class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 size-9"
@@ -233,6 +235,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state without is
           data-slot="table-cell"
         >
           <button
+            aria-controls="meeting-detail-id-1"
             aria-expanded="false"
             aria-label="Expand meeting with Jane Rep"
             class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 size-9"
@@ -431,6 +434,7 @@ exports[`MeetingsSection > matches snapshot with meetings 1`] = `
               data-slot="table-cell"
             >
               <button
+                aria-controls="meeting-detail-id-1"
                 aria-expanded="false"
                 aria-label="Expand meeting with Jane Rep"
                 class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 size-9"

--- a/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
   <table>
     <tbody>
       <tr
-        class="border-b transition-colors data-[state=selected]:bg-muted cursor-pointer has-aria-expanded:bg-accent hover:bg-accent"
+        class="border-b transition-colors data-[state=selected]:bg-muted has-aria-expanded:bg-accent cursor-pointer hover:bg-accent"
         data-slot="table-row"
       >
         <td
@@ -130,7 +130,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
   <table>
     <tbody>
       <tr
-        class="border-b transition-colors data-[state=selected]:bg-muted cursor-pointer has-aria-expanded:bg-accent hover:bg-accent"
+        class="border-b transition-colors data-[state=selected]:bg-muted has-aria-expanded:bg-accent cursor-pointer hover:bg-accent"
         data-slot="table-row"
       >
         <td
@@ -228,7 +228,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state without is
   <table>
     <tbody>
       <tr
-        class="border-b transition-colors data-[state=selected]:bg-muted cursor-pointer has-aria-expanded:bg-accent hover:bg-accent"
+        class="border-b transition-colors data-[state=selected]:bg-muted has-aria-expanded:bg-accent cursor-pointer hover:bg-accent"
         data-slot="table-row"
       >
         <td
@@ -427,7 +427,7 @@ exports[`MeetingsSection > matches snapshot with meetings 1`] = `
           data-slot="table-body"
         >
           <tr
-            class="border-b transition-colors data-[state=selected]:bg-muted cursor-pointer has-aria-expanded:bg-accent hover:bg-accent"
+            class="border-b transition-colors data-[state=selected]:bg-muted has-aria-expanded:bg-accent cursor-pointer hover:bg-accent"
             data-slot="table-row"
           >
             <td

--- a/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
   <table>
     <tbody>
       <tr
-        class="has-aria-expanded:bg-muted border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted"
+        class="border-b transition-colors data-[state=selected]:bg-muted cursor-pointer has-aria-expanded:bg-accent hover:bg-accent"
         data-slot="table-row"
       >
         <td
@@ -102,6 +102,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
             class="lucide lucide-circle-check-big m-auto h-4 w-4 text-green-600"
             fill="none"
             height="24"
+            role="img"
             stroke="currentColor"
             stroke-linecap="round"
             stroke-linejoin="round"
@@ -129,7 +130,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
   <table>
     <tbody>
       <tr
-        class="has-aria-expanded:bg-muted border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted"
+        class="border-b transition-colors data-[state=selected]:bg-muted cursor-pointer has-aria-expanded:bg-accent hover:bg-accent"
         data-slot="table-row"
       >
         <td
@@ -227,7 +228,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state without is
   <table>
     <tbody>
       <tr
-        class="has-aria-expanded:bg-muted border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted"
+        class="border-b transition-colors data-[state=selected]:bg-muted cursor-pointer has-aria-expanded:bg-accent hover:bg-accent"
         data-slot="table-row"
       >
         <td
@@ -426,7 +427,7 @@ exports[`MeetingsSection > matches snapshot with meetings 1`] = `
           data-slot="table-body"
         >
           <tr
-            class="has-aria-expanded:bg-muted border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted"
+            class="border-b transition-colors data-[state=selected]:bg-muted cursor-pointer has-aria-expanded:bg-accent hover:bg-accent"
             data-slot="table-row"
           >
             <td

--- a/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
@@ -120,6 +120,11 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
           </svg>
         </td>
       </tr>
+      <tr
+        class="has-aria-expanded:bg-muted border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted hidden"
+        data-slot="table-row"
+        id="meeting-detail-id-1"
+      />
     </tbody>
   </table>
 </DocumentFragment>
@@ -218,6 +223,11 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
           data-slot="table-cell"
         />
       </tr>
+      <tr
+        class="has-aria-expanded:bg-muted border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted hidden"
+        data-slot="table-row"
+        id="meeting-detail-id-1"
+      />
     </tbody>
   </table>
 </DocumentFragment>
@@ -317,6 +327,11 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state without is
           Alice Lead
         </td>
       </tr>
+      <tr
+        class="has-aria-expanded:bg-muted border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted hidden"
+        data-slot="table-row"
+        id="meeting-detail-id-1"
+      />
     </tbody>
   </table>
 </DocumentFragment>
@@ -511,6 +526,11 @@ exports[`MeetingsSection > matches snapshot with meetings 1`] = `
               —
             </td>
           </tr>
+          <tr
+            class="has-aria-expanded:bg-muted border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted hidden"
+            data-slot="table-row"
+            id="meeting-detail-id-1"
+          />
         </tbody>
       </table>
     </div>

--- a/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
   <table>
     <tbody>
       <tr
-        class="border-b transition-colors data-[state=selected]:bg-muted has-aria-expanded:bg-accent cursor-pointer hover:bg-accent"
+        class="has-aria-expanded:bg-muted border-b transition-colors data-[state=selected]:bg-muted cursor-pointer hover:bg-accent"
         data-slot="table-row"
       >
         <td
@@ -130,7 +130,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state with isPas
   <table>
     <tbody>
       <tr
-        class="border-b transition-colors data-[state=selected]:bg-muted has-aria-expanded:bg-accent cursor-pointer hover:bg-accent"
+        class="has-aria-expanded:bg-muted border-b transition-colors data-[state=selected]:bg-muted cursor-pointer hover:bg-accent"
         data-slot="table-row"
       >
         <td
@@ -228,7 +228,7 @@ exports[`MeetingRow (collapsed) > matches snapshot in collapsed state without is
   <table>
     <tbody>
       <tr
-        class="border-b transition-colors data-[state=selected]:bg-muted has-aria-expanded:bg-accent cursor-pointer hover:bg-accent"
+        class="has-aria-expanded:bg-muted border-b transition-colors data-[state=selected]:bg-muted cursor-pointer hover:bg-accent"
         data-slot="table-row"
       >
         <td
@@ -427,7 +427,7 @@ exports[`MeetingsSection > matches snapshot with meetings 1`] = `
           data-slot="table-body"
         >
           <tr
-            class="border-b transition-colors data-[state=selected]:bg-muted has-aria-expanded:bg-accent cursor-pointer hover:bg-accent"
+            class="has-aria-expanded:bg-muted border-b transition-colors data-[state=selected]:bg-muted cursor-pointer hover:bg-accent"
             data-slot="table-row"
           >
             <td

--- a/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
+++ b/__tests__/components/meetings/__snapshots__/meetings-section.test.tsx.snap
@@ -354,7 +354,7 @@ exports[`MeetingsSection > matches snapshot with meetings 1`] = `
       Upcoming Meetings
     </h2>
     <div
-      class="relative w-full overflow-x-auto rounded-md border"
+      class="relative w-full overflow-x-auto rounded-md border @container"
       data-slot="table-container"
     >
       <table

--- a/__tests__/components/meetings/meeting-detail-view.test.tsx
+++ b/__tests__/components/meetings/meeting-detail-view.test.tsx
@@ -300,7 +300,7 @@ describe("MeetingDetailView — champion level", () => {
         onEdit={vi.fn()}
       />,
     );
-    expect(screen.getByText(/3 – Supporter/)).toBeInTheDocument();
+    expect(screen.getByText(/3 – Advocate/)).toBeInTheDocument();
   });
 
   it("renders score 0 correctly", () => {

--- a/__tests__/components/meetings/meeting-detail-view.test.tsx
+++ b/__tests__/components/meetings/meeting-detail-view.test.tsx
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MeetingDetailView } from "@/components/meetings/meeting-detail-view";
+import type { MeetingDetail } from "@/lib/meetings/types";
+
+function makeMeeting(overrides: Partial<MeetingDetail> = {}): MeetingDetail {
+  return {
+    id: "meeting-1",
+    meeting_date: "2099-06-01",
+    meeting_time: null,
+    meeting_timezone: "America/New_York",
+    representative_id: "rep-1",
+    representative_bioguide_id: "R000001",
+    representative_name: "Jane Rep",
+    representative_state: "WA",
+    representative_district: 9,
+    representative_party: "Democrat",
+    congressional_contact_id: null,
+    congressional_contact_name: "Jane Rep",
+    primary_team_id: null,
+    primary_team_name: null,
+    primary_team_slug: null,
+    scheduling_lead_name: null,
+    follow_up_date: null,
+    champion_score: null,
+    notes: null,
+    location: null,
+    links: [],
+    delegation_members: [],
+    represented_teams: [],
+    ...overrides,
+  };
+}
+
+describe("MeetingDetailView — Edit Meeting button", () => {
+  it("renders the Edit Meeting button", () => {
+    render(<MeetingDetailView meeting={makeMeeting()} onEdit={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /Edit Meeting/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onEdit when Edit Meeting is clicked", async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    render(<MeetingDetailView meeting={makeMeeting()} onEdit={onEdit} />);
+    await user.click(screen.getByRole("button", { name: /Edit Meeting/i }));
+    expect(onEdit).toHaveBeenCalledOnce();
+  });
+});
+
+describe("MeetingDetailView — time", () => {
+  it("renders meeting time with timezone abbreviation", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({
+          meeting_time: "14:30",
+          meeting_timezone: "America/New_York",
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/2:30 PM/)).toBeInTheDocument();
+  });
+
+  it("omits time section when meeting_time is null", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ meeting_time: null })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/AM|PM/)).not.toBeInTheDocument();
+  });
+});
+
+describe("MeetingDetailView — location", () => {
+  it("renders location when set", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ location: "Capitol Hill, Room 101" })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Capitol Hill, Room 101")).toBeInTheDocument();
+  });
+
+  it("omits location section when null", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ location: null })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByText(/Location/i, { selector: "p" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("MeetingDetailView — notes with accent bar", () => {
+  it("renders notes text", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ notes: "Key talking points here." })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Key talking points here.")).toBeInTheDocument();
+  });
+
+  it("renders notes inside a left-accent-bar container", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ notes: "Accent bar notes" })}
+        onEdit={vi.fn()}
+      />,
+    );
+    const notesEl = screen.getByText("Accent bar notes");
+    expect(notesEl.closest("div")).toHaveClass("border-l-4");
+  });
+
+  it("omits notes section when null", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ notes: null })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByText(/Notes/i, { selector: "p" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("MeetingDetailView — links", () => {
+  it("renders each link as a clickable anchor with label", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({
+          links: [
+            { label: "Agenda", url: "https://example.com/agenda" },
+            { label: "Briefing", url: "https://example.com/brief" },
+          ],
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    const agendaLink = screen.getByRole("link", { name: /Agenda/i });
+    expect(agendaLink).toHaveAttribute("href", "https://example.com/agenda");
+    expect(agendaLink).toHaveAttribute("target", "_blank");
+
+    const briefingLink = screen.getByRole("link", { name: /Briefing/i });
+    expect(briefingLink).toHaveAttribute("href", "https://example.com/brief");
+  });
+
+  it("omits links section when empty", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ links: [] })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByText(/Links/i, { selector: "p" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("MeetingDetailView — delegation", () => {
+  it("shows delegation member names and role labels", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({
+          delegation_members: [
+            {
+              id: "dm-1",
+              user_id: "u-1",
+              display_name: "Alice Smith",
+              role: "scheduling_lead",
+              team_id: null,
+              team_name_snapshot: null,
+            },
+            {
+              id: "dm-2",
+              user_id: "u-2",
+              display_name: "Bob Jones",
+              role: "attendee_talking",
+              team_id: null,
+              team_name_snapshot: null,
+            },
+          ],
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    expect(screen.getByText(/Scheduling Lead/i)).toBeInTheDocument();
+    expect(screen.getByText("Bob Jones")).toBeInTheDocument();
+    expect(screen.getByText(/Attendee \(Talking\)/i)).toBeInTheDocument();
+  });
+
+  it("shows None when delegation is empty", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ delegation_members: [] })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("None")).toBeInTheDocument();
+  });
+});
+
+describe("MeetingDetailView — PIH Team Member sub-section", () => {
+  it("shows PIH Team Member section only for pih_team_member role", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({
+          delegation_members: [
+            {
+              id: "dm-1",
+              user_id: "u-1",
+              display_name: "Carol Pih",
+              role: "pih_team_member",
+              team_id: null,
+              team_name_snapshot: null,
+            },
+            {
+              id: "dm-2",
+              user_id: "u-2",
+              display_name: "Dave Note",
+              role: "note_taker",
+              team_id: null,
+              team_name_snapshot: null,
+            },
+          ],
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    const headings = screen.getAllByText(/PIH Team Member/i);
+    expect(headings.length).toBeGreaterThanOrEqual(1);
+    // Carol appears in both Delegation list and PIH Team Member sub-section
+    expect(screen.getAllByText("Carol Pih")).toHaveLength(2);
+    // Dave only appears in Delegation
+    expect(screen.getAllByText("Dave Note")).toHaveLength(1);
+  });
+
+  it("omits PIH Team Member sub-section when no pih_team_member role", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({
+          delegation_members: [
+            {
+              id: "dm-1",
+              user_id: "u-1",
+              display_name: "Eve Attendee",
+              role: "attendee_listening",
+              team_id: null,
+              team_name_snapshot: null,
+            },
+          ],
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    // Only one "PIH Team Member" label: in the full delegation list role column
+    expect(
+      screen.queryByText(/PIH Team Member/i, { selector: "p" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("MeetingDetailView — champion level", () => {
+  it("renders champion score as '{n} – {Label}'", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ champion_score: 3 })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/3 – Supporter/)).toBeInTheDocument();
+  });
+
+  it("renders score 0 correctly", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ champion_score: 0 })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/0 – Opposed/)).toBeInTheDocument();
+  });
+
+  it("renders score 5 correctly", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ champion_score: 5 })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/5 – Champion/)).toBeInTheDocument();
+  });
+
+  it("omits Champion Level section when score is null", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({ champion_score: null })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByText(/Champion Level/i, { selector: "p" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("MeetingDetailView — snapshots", () => {
+  it("matches snapshot with all fields set", () => {
+    const { asFragment } = render(
+      <MeetingDetailView
+        meeting={makeMeeting({
+          meeting_time: "09:00",
+          meeting_timezone: "America/New_York",
+          location: "Virtual",
+          notes: "Brief discussion on policy.",
+          links: [{ label: "Deck", url: "https://example.com/deck" }],
+          champion_score: 4,
+          delegation_members: [
+            {
+              id: "dm-1",
+              user_id: "u-1",
+              display_name: "Alice Smith",
+              role: "scheduling_lead",
+              team_id: null,
+              team_name_snapshot: "Team A",
+            },
+            {
+              id: "dm-2",
+              user_id: "u-2",
+              display_name: "Bob Jones",
+              role: "pih_team_member",
+              team_id: null,
+              team_name_snapshot: "Team B",
+            },
+          ],
+          represented_teams: ["Team A", "Team B"],
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("matches snapshot with minimal fields (no optional data)", () => {
+    const { asFragment } = render(
+      <MeetingDetailView meeting={makeMeeting()} onEdit={vi.fn()} />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/__tests__/components/meetings/meeting-detail-view.test.tsx
+++ b/__tests__/components/meetings/meeting-detail-view.test.tsx
@@ -178,6 +178,7 @@ describe("MeetingDetailView — delegation", () => {
               id: "dm-1",
               user_id: "u-1",
               display_name: "Alice Smith",
+              email: "alice@example.com",
               role: "scheduling_lead",
               team_id: null,
               team_name_snapshot: null,
@@ -186,6 +187,7 @@ describe("MeetingDetailView — delegation", () => {
               id: "dm-2",
               user_id: "u-2",
               display_name: "Bob Jones",
+              email: null,
               role: "attendee_talking",
               team_id: null,
               team_name_snapshot: null,
@@ -197,8 +199,76 @@ describe("MeetingDetailView — delegation", () => {
     );
     expect(screen.getByText("Alice Smith")).toBeInTheDocument();
     expect(screen.getByText(/Scheduling Lead/i)).toBeInTheDocument();
-    expect(screen.getByText("Bob Jones")).toBeInTheDocument();
-    expect(screen.getByText(/Attendee \(Talking\)/i)).toBeInTheDocument();
+    // attendee_talking renders as a labeled avatar button, not visible text
+    expect(
+      screen.getByRole("button", { name: /Bob Jones.*Attendee \(Talking\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows email for scheduling_lead when present", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({
+          delegation_members: [
+            {
+              id: "dm-1",
+              user_id: "u-1",
+              display_name: "Alice Smith",
+              email: "alice@example.com",
+              role: "scheduling_lead",
+              team_id: null,
+              team_name_snapshot: null,
+            },
+          ],
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/alice@example\.com/)).toBeInTheDocument();
+  });
+
+  it("shows email for pih_team_member when present", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({
+          delegation_members: [
+            {
+              id: "dm-1",
+              user_id: "u-1",
+              display_name: "Carol Pih",
+              email: "carol@example.com",
+              role: "pih_team_member",
+              team_id: null,
+              team_name_snapshot: null,
+            },
+          ],
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/carol@example\.com/)).toBeInTheDocument();
+  });
+
+  it("does not show email for attendee roles", () => {
+    render(
+      <MeetingDetailView
+        meeting={makeMeeting({
+          delegation_members: [
+            {
+              id: "dm-1",
+              user_id: "u-1",
+              display_name: "Bob Jones",
+              email: "bob@example.com",
+              role: "attendee_talking",
+              team_id: null,
+              team_name_snapshot: null,
+            },
+          ],
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/bob@example\.com/)).not.toBeInTheDocument();
   });
 
   it("shows None when delegation is empty", () => {
@@ -209,66 +279,6 @@ describe("MeetingDetailView — delegation", () => {
       />,
     );
     expect(screen.getByText("None")).toBeInTheDocument();
-  });
-});
-
-describe("MeetingDetailView — PIH Team Member sub-section", () => {
-  it("shows PIH Team Member section only for pih_team_member role", () => {
-    render(
-      <MeetingDetailView
-        meeting={makeMeeting({
-          delegation_members: [
-            {
-              id: "dm-1",
-              user_id: "u-1",
-              display_name: "Carol Pih",
-              role: "pih_team_member",
-              team_id: null,
-              team_name_snapshot: null,
-            },
-            {
-              id: "dm-2",
-              user_id: "u-2",
-              display_name: "Dave Note",
-              role: "note_taker",
-              team_id: null,
-              team_name_snapshot: null,
-            },
-          ],
-        })}
-        onEdit={vi.fn()}
-      />,
-    );
-    const headings = screen.getAllByText(/PIH Team Member/i);
-    expect(headings.length).toBeGreaterThanOrEqual(1);
-    // Carol appears in both Delegation list and PIH Team Member sub-section
-    expect(screen.getAllByText("Carol Pih")).toHaveLength(2);
-    // Dave only appears in Delegation
-    expect(screen.getAllByText("Dave Note")).toHaveLength(1);
-  });
-
-  it("omits PIH Team Member sub-section when no pih_team_member role", () => {
-    render(
-      <MeetingDetailView
-        meeting={makeMeeting({
-          delegation_members: [
-            {
-              id: "dm-1",
-              user_id: "u-1",
-              display_name: "Eve Attendee",
-              role: "attendee_listening",
-              team_id: null,
-              team_name_snapshot: null,
-            },
-          ],
-        })}
-        onEdit={vi.fn()}
-      />,
-    );
-    // Only one "PIH Team Member" label: in the full delegation list role column
-    expect(
-      screen.queryByText(/PIH Team Member/i, { selector: "p" }),
-    ).not.toBeInTheDocument();
   });
 });
 
@@ -332,6 +342,7 @@ describe("MeetingDetailView — snapshots", () => {
               id: "dm-1",
               user_id: "u-1",
               display_name: "Alice Smith",
+              email: "alice@example.com",
               role: "scheduling_lead",
               team_id: null,
               team_name_snapshot: "Team A",
@@ -340,6 +351,7 @@ describe("MeetingDetailView — snapshots", () => {
               id: "dm-2",
               user_id: "u-2",
               display_name: "Bob Jones",
+              email: "bob@example.com",
               role: "pih_team_member",
               team_id: null,
               team_name_snapshot: "Team B",

--- a/__tests__/components/meetings/meeting-detail-view.test.tsx
+++ b/__tests__/components/meetings/meeting-detail-view.test.tsx
@@ -177,6 +177,8 @@ describe("MeetingDetailView — delegation", () => {
             {
               id: "dm-1",
               user_id: "u-1",
+              first_name: "Alice",
+              last_name: "Smith",
               display_name: "Alice Smith",
               email: "alice@example.com",
               role: "scheduling_lead",
@@ -186,6 +188,8 @@ describe("MeetingDetailView — delegation", () => {
             {
               id: "dm-2",
               user_id: "u-2",
+              first_name: "Bob",
+              last_name: "Jones",
               display_name: "Bob Jones",
               email: null,
               role: "attendee_talking",
@@ -213,6 +217,8 @@ describe("MeetingDetailView — delegation", () => {
             {
               id: "dm-1",
               user_id: "u-1",
+              first_name: "Alice",
+              last_name: "Smith",
               display_name: "Alice Smith",
               email: "alice@example.com",
               role: "scheduling_lead",
@@ -235,6 +241,8 @@ describe("MeetingDetailView — delegation", () => {
             {
               id: "dm-1",
               user_id: "u-1",
+              first_name: "Carol",
+              last_name: "Pih",
               display_name: "Carol Pih",
               email: "carol@example.com",
               role: "pih_team_member",
@@ -257,6 +265,8 @@ describe("MeetingDetailView — delegation", () => {
             {
               id: "dm-1",
               user_id: "u-1",
+              first_name: "Bob",
+              last_name: "Jones",
               display_name: "Bob Jones",
               email: "bob@example.com",
               role: "attendee_talking",
@@ -341,6 +351,8 @@ describe("MeetingDetailView — snapshots", () => {
             {
               id: "dm-1",
               user_id: "u-1",
+              first_name: "Alice",
+              last_name: "Smith",
               display_name: "Alice Smith",
               email: "alice@example.com",
               role: "scheduling_lead",
@@ -350,6 +362,8 @@ describe("MeetingDetailView — snapshots", () => {
             {
               id: "dm-2",
               user_id: "u-2",
+              first_name: "Bob",
+              last_name: "Jones",
               display_name: "Bob Jones",
               email: "bob@example.com",
               role: "pih_team_member",

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { ExternalLink, Settings } from "lucide-react";
+import { ExternalLink, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { MeetingDetail, DelegationRole } from "@/lib/meetings/types";
+import { formatTime } from "@/lib/meetings/format";
 
 const ROLE_LABELS: Record<DelegationRole, string> = {
   scheduling_lead: "Scheduling Lead",
@@ -35,127 +36,138 @@ export function MeetingDetailView({
   onEdit,
 }: {
   meeting: MeetingDetail;
-  onEdit: () => void;
+  onEdit?: () => void;
 }) {
   const pihMembers = meeting.delegation_members.filter(
     (m) => m.role === "pih_team_member",
   );
 
   return (
-    <div className="border-t p-6">
-      <div className="flex items-start gap-4">
-        <div className="grid flex-1 gap-6 @[600px]:grid-cols-2">
-          <div className="flex flex-col gap-4">
-            {meeting.location && (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Location
-                </p>
-                <p className="mt-1 text-sm">{meeting.location}</p>
-              </div>
-            )}
-            {meeting.notes && (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Notes
-                </p>
-                <div className="mt-1 border-l-4 border-muted pl-3">
-                  <p className="text-sm">{meeting.notes}</p>
-                </div>
-              </div>
-            )}
-            {meeting.links.length > 0 && (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Links
-                </p>
-                <ul className="mt-1 flex flex-col gap-1">
-                  {meeting.links.map((link, i) => (
-                    <li key={i}>
-                      <a
-                        href={link.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 text-sm text-primary-dark underline-offset-4 hover:underline"
-                      >
-                        <ExternalLink
-                          aria-hidden="true"
-                          className="h-3 w-3 shrink-0"
-                        />
-                        {link.label}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-          </div>
-
-          <div className="flex flex-col gap-4">
+    <div className="border-t p-6 @container">
+      <div className="grid gap-6 @[600px]:grid-cols-2">
+        <div className="flex flex-col gap-4">
+          {meeting.meeting_time && (
             <div>
               <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Delegation
+                Time
               </p>
-              {meeting.delegation_members.length === 0 ? (
-                <p className="mt-1 text-sm text-muted-foreground">None</p>
-              ) : (
-                <ul className="mt-1 flex flex-col gap-2">
-                  {meeting.delegation_members.map((m) => (
-                    <li key={m.id} className="flex items-center gap-2">
-                      <span
-                        aria-hidden="true"
-                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
-                      >
-                        {initials(m.display_name)}
-                      </span>
-                      <span className="text-sm">{m.display_name}</span>
-                      <span className="text-xs text-muted-foreground">
-                        — {ROLE_LABELS[m.role]}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              )}
+              <p className="mt-1 text-sm">
+                {formatTime(
+                  meeting.meeting_date,
+                  meeting.meeting_time,
+                  meeting.meeting_timezone,
+                )}
+              </p>
             </div>
-
-            {pihMembers.length > 0 && (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  PIH Team Member
-                </p>
-                <ul className="mt-1 flex flex-col gap-1">
-                  {pihMembers.map((m) => (
-                    <li key={m.id} className="text-sm">
-                      {m.display_name}
-                    </li>
-                  ))}
-                </ul>
+          )}
+          {meeting.location && (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Location
+              </p>
+              <p className="mt-1 text-sm">{meeting.location}</p>
+            </div>
+          )}
+          {meeting.notes && (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Notes
+              </p>
+              <div className="mt-1 border-l-4 border-muted pl-3">
+                <p className="text-sm">{meeting.notes}</p>
               </div>
-            )}
+            </div>
+          )}
+          {meeting.links.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Links
+              </p>
+              <ul className="mt-1 flex flex-col gap-1">
+                {meeting.links.map((link) => (
+                  <li key={`${link.label}::${link.url}`}>
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-sm text-primary-dark underline-offset-4 hover:underline"
+                    >
+                      <ExternalLink
+                        aria-hidden="true"
+                        className="h-3 w-3 shrink-0"
+                      />
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
 
-            {meeting.champion_score != null && (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Champion Level
-                </p>
-                <p className="mt-1 text-sm">
-                  {meeting.champion_score} –{" "}
-                  {CHAMPION_LABELS[meeting.champion_score] ?? ""}
-                </p>
-              </div>
+        <div className="flex flex-col gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Delegation
+            </p>
+            {meeting.delegation_members.length === 0 ? (
+              <p className="mt-1 text-sm text-muted-foreground">None</p>
+            ) : (
+              <ul className="mt-1 flex flex-col gap-2">
+                {meeting.delegation_members.map((m) => (
+                  <li key={m.id} className="flex items-center gap-2">
+                    <span
+                      aria-hidden="true"
+                      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
+                    >
+                      {initials(m.display_name)}
+                    </span>
+                    <span className="text-sm">{m.display_name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      — {ROLE_LABELS[m.role]}
+                    </span>
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
+
+          {pihMembers.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                PIH Team Member
+              </p>
+              <ul className="mt-1 flex flex-col gap-1">
+                {pihMembers.map((m) => (
+                  <li key={m.id} className="text-sm">
+                    {m.display_name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {meeting.champion_score != null && (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Champion Level
+              </p>
+              <p className="mt-1 text-sm">
+                {meeting.champion_score} –{" "}
+                {CHAMPION_LABELS[meeting.champion_score] ?? "Unknown"}
+              </p>
+            </div>
+          )}
         </div>
-        <Button
-          variant="outline"
-          size="icon"
-          aria-label="Edit meeting"
-          onClick={onEdit}
-          className="shrink-0"
-        >
-          <Settings aria-hidden="true" className="h-4 w-4" />
-        </Button>
       </div>
+      {onEdit && (
+        <div className="mt-6">
+          <Button variant="outline" size="sm" onClick={onEdit}>
+            <Pencil aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
+            Edit Meeting
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -14,6 +14,7 @@ import type {
   DelegationMember,
   DelegationRole,
 } from "@/lib/meetings/types";
+import { formatTime } from "@/lib/meetings/format";
 
 const ROLE_LABELS: Record<DelegationRole, string> = {
   scheduling_lead: "Scheduling Lead",
@@ -201,6 +202,18 @@ export function MeetingDetailView({
         </div>
 
         <div className="flex flex-col gap-4">
+          {meeting.meeting_time && (
+            <div>
+              <p className={SECTION_LABEL_CLASSNAME}>Time</p>
+              <p className="mt-1 text-sm">
+                {formatTime(
+                  meeting.meeting_date,
+                  meeting.meeting_time,
+                  meeting.meeting_timezone,
+                )}
+              </p>
+            </div>
+          )}
           {meeting.location && (
             <div>
               <p className={SECTION_LABEL_CLASSNAME}>Location</p>

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -248,9 +248,13 @@ export function MeetingDetailView({
                     )),
                 )}
                 {(() => {
-                  const attendees = meeting.delegation_members.filter((m) =>
-                    MEMBER_ROLES.includes(m.role),
-                  );
+                  const attendees = meeting.delegation_members
+                    .filter((m) => MEMBER_ROLES.includes(m.role))
+                    .sort(
+                      (a, b) =>
+                        MEMBER_ROLES.indexOf(a.role) -
+                        MEMBER_ROLES.indexOf(b.role),
+                    );
                   if (attendees.length === 0) return null;
                   return (
                     <div className="flex flex-col gap-1">

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -32,7 +32,11 @@ function DelegationMemberRow({ member }: { member: DelegationMember }) {
         {ROLE_LABELS[member.role]}
       </span>
       <span className="flex items-center gap-2">
-        <AvatarInitialsCircle name={member.display_name} aria-hidden="true" />
+        <AvatarInitialsCircle
+          firstName={member.first_name}
+          lastName={member.last_name}
+          aria-hidden="true"
+        />
         <span className="min-w-0 flex-1">
           <span className="text-sm font-medium">{member.display_name}</span>
           {member.email && (

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -1,9 +1,19 @@
 "use client";
 
+import { useState, useEffect, useRef } from "react";
 import { ExternalLink, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import type { MeetingDetail, DelegationRole } from "@/lib/meetings/types";
-import { formatTime } from "@/lib/meetings/format";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type {
+  MeetingDetail,
+  DelegationMember,
+  DelegationRole,
+} from "@/lib/meetings/types";
 
 const ROLE_LABELS: Record<DelegationRole, string> = {
   scheduling_lead: "Scheduling Lead",
@@ -12,6 +22,81 @@ const ROLE_LABELS: Record<DelegationRole, string> = {
   pih_team_member: "PIH Team Member",
   note_taker: "Note Taker",
 };
+
+const MEMBER_ROLE_COLORS: Partial<Record<DelegationRole, string>> = {
+  attendee_talking: "bg-blue-500 text-white",
+  attendee_listening: "bg-violet-500 text-white",
+  note_taker: "bg-amber-500 text-white",
+};
+
+const MEMBER_ROLES: DelegationRole[] = [
+  "attendee_talking",
+  "attendee_listening",
+  "note_taker",
+];
+
+function MemberAvatar({ member }: { member: DelegationMember }) {
+  const [clicked, setClicked] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const colorClass =
+    MEMBER_ROLE_COLORS[member.role] ?? "bg-muted text-foreground";
+
+  useEffect(() => {
+    if (!clicked) return;
+    function handleClose(e: MouseEvent | KeyboardEvent) {
+      if (e instanceof KeyboardEvent) {
+        if (e.key === "Escape") setClicked(false);
+        return;
+      }
+      if (buttonRef.current && !buttonRef.current.contains(e.target as Node)) {
+        setClicked(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClose);
+    document.addEventListener("keydown", handleClose);
+    return () => {
+      document.removeEventListener("mousedown", handleClose);
+      document.removeEventListener("keydown", handleClose);
+    };
+  }, [clicked]);
+
+  return (
+    <TooltipProvider>
+      <Tooltip open={hovered || clicked}>
+        <TooltipTrigger asChild>
+          <button
+            ref={buttonRef}
+            type="button"
+            className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${colorClass}`}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+            onClick={() => setClicked((v) => !v)}
+            aria-label={`${member.display_name} — ${ROLE_LABELS[member.role]}`}
+          >
+            {initials(member.display_name)}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className="max-w-48 bg-accent text-accent-foreground"
+          arrowClassName="bg-accent fill-accent"
+        >
+          <p className="text-sm font-bold">{ROLE_LABELS[member.role]}</p>
+          <p className="text-sm font-medium">{member.display_name}</p>
+          {member.email && (
+            <a
+              href={`mailto:${member.email}`}
+              className="text-sm italic underline-offset-4 hover:underline"
+            >
+              {member.email}
+            </a>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 const CHAMPION_LABELS: Record<number, string> = {
   0: "Opposed",
@@ -38,39 +123,72 @@ export function MeetingDetailView({
   meeting: MeetingDetail;
   onEdit?: () => void;
 }) {
-  const pihMembers = meeting.delegation_members.filter(
-    (m) => m.role === "pih_team_member",
-  );
-
   return (
-    <div className="border-t p-6 @container">
+    <div className="relative p-6">
+      {onEdit && (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                className="absolute right-4 top-4 h-8 w-8"
+                onClick={onEdit}
+                aria-label="Edit meeting"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Edit meeting</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
       <div className="grid gap-6 @[600px]:grid-cols-2">
         <div className="flex flex-col gap-4">
-          {meeting.meeting_time && (
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Time
-              </p>
-              <p className="mt-1 text-sm">
-                {formatTime(
-                  meeting.meeting_date,
-                  meeting.meeting_time,
-                  meeting.meeting_timezone,
+          {(() => {
+            const isPast =
+              meeting.meeting_date < new Date().toISOString().slice(0, 10);
+            const showChampion = isPast || meeting.champion_score != null;
+            const showFollowUp = isPast || meeting.follow_up_date != null;
+            if (!showChampion && !showFollowUp) return null;
+            return (
+              <div className="flex gap-6">
+                {showChampion && (
+                  <div>
+                    <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
+                      Champion Level
+                    </p>
+                    <p className="mt-1 text-sm">
+                      {meeting.champion_score != null
+                        ? `${meeting.champion_score} – ${CHAMPION_LABELS[meeting.champion_score] ?? "Unknown"}`
+                        : "—"}
+                    </p>
+                  </div>
                 )}
-              </p>
-            </div>
-          )}
-          {meeting.location && (
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Location
-              </p>
-              <p className="mt-1 text-sm">{meeting.location}</p>
-            </div>
-          )}
+                {showFollowUp && (
+                  <div>
+                    <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
+                      Follow-up
+                    </p>
+                    <p className="mt-1 text-sm">
+                      {meeting.follow_up_date
+                        ? new Date(
+                            meeting.follow_up_date + "T00:00:00",
+                          ).toLocaleDateString("en-US", {
+                            month: "short",
+                            day: "numeric",
+                            year: "numeric",
+                          })
+                        : "—"}
+                    </p>
+                  </div>
+                )}
+              </div>
+            );
+          })()}
           {meeting.notes && (
             <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
                 Notes
               </p>
               <div className="mt-1 border-l-4 border-muted pl-3">
@@ -80,7 +198,7 @@ export function MeetingDetailView({
           )}
           {meeting.links.length > 0 && (
             <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
                 Links
               </p>
               <ul className="mt-1 flex flex-col gap-1">
@@ -106,68 +224,79 @@ export function MeetingDetailView({
         </div>
 
         <div className="flex flex-col gap-4">
+          {meeting.location && (
+            <div>
+              <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
+                Location
+              </p>
+              <p className="mt-1 text-sm">{meeting.location}</p>
+            </div>
+          )}
           <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
               Delegation
             </p>
             {meeting.delegation_members.length === 0 ? (
               <p className="mt-1 text-sm text-muted-foreground">None</p>
             ) : (
-              <ul className="mt-1 flex flex-col gap-2">
-                {meeting.delegation_members.map((m) => (
-                  <li key={m.id} className="flex items-center gap-2">
-                    <span
-                      aria-hidden="true"
-                      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
-                    >
-                      {initials(m.display_name)}
-                    </span>
-                    <span className="text-sm">{m.display_name}</span>
-                    <span className="text-xs text-muted-foreground">
-                      — {ROLE_LABELS[m.role]}
-                    </span>
-                  </li>
-                ))}
-              </ul>
+              <div className="mt-2 flex flex-col gap-3">
+                {(
+                  ["scheduling_lead", "pih_team_member"] as DelegationRole[]
+                ).flatMap((role) =>
+                  meeting.delegation_members
+                    .filter((m) => m.role === role)
+                    .map((m) => (
+                      <div key={m.id} className="flex flex-col gap-0.5">
+                        <span className="text-xs text-muted-foreground">
+                          {ROLE_LABELS[m.role]}
+                        </span>
+                        <span className="flex items-center gap-2">
+                          <span
+                            aria-hidden="true"
+                            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
+                          >
+                            {initials(m.display_name)}
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="text-sm font-medium">
+                              {m.display_name}
+                            </span>
+                            {m.email && (
+                              <a
+                                href={`mailto:${m.email}`}
+                                className="ml-1.5 text-xs text-muted-foreground underline-offset-4 hover:underline"
+                              >
+                                {m.email}
+                              </a>
+                            )}
+                          </span>
+                        </span>
+                      </div>
+                    )),
+                )}
+                {(() => {
+                  const attendees = meeting.delegation_members.filter((m) =>
+                    MEMBER_ROLES.includes(m.role),
+                  );
+                  if (attendees.length === 0) return null;
+                  return (
+                    <div className="flex flex-col gap-1">
+                      <span className="text-xs text-muted-foreground">
+                        Attendees
+                      </span>
+                      <div className="flex flex-wrap gap-1.5">
+                        {attendees.map((m) => (
+                          <MemberAvatar key={m.id} member={m} />
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })()}
+              </div>
             )}
           </div>
-
-          {pihMembers.length > 0 && (
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                PIH Team Member
-              </p>
-              <ul className="mt-1 flex flex-col gap-1">
-                {pihMembers.map((m) => (
-                  <li key={m.id} className="text-sm">
-                    {m.display_name}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-
-          {meeting.champion_score != null && (
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Champion Level
-              </p>
-              <p className="mt-1 text-sm">
-                {meeting.champion_score} –{" "}
-                {CHAMPION_LABELS[meeting.champion_score] ?? "Unknown"}
-              </p>
-            </div>
-          )}
         </div>
       </div>
-      {onEdit && (
-        <div className="mt-6">
-          <Button variant="outline" size="sm" onClick={onEdit}>
-            <Pencil aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
-            Edit Meeting
-          </Button>
-        </div>
-      )}
     </div>
   );
 }

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -1,120 +1,16 @@
 "use client";
 
-import {
-  useState,
-  useEffect,
-  useRef,
-  type ComponentPropsWithoutRef,
-} from "react";
 import { cn } from "@/lib/utils";
 import { ExternalLink, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import type {
-  MeetingDetail,
-  DelegationMember,
-  DelegationRole,
-} from "@/lib/meetings/types";
-import {
-  formatDate,
-  formatTime,
-  initials,
-  LINK_CN,
-} from "@/lib/meetings/format";
-
-const ROLE_LABELS: Record<DelegationRole, string> = {
-  scheduling_lead: "Scheduling Lead",
-  attendee_talking: "Attendee (Talking)",
-  attendee_listening: "Attendee (Listening)",
-  pih_team_member: "PIH Team Member",
-  note_taker: "Note Taker",
-};
-
-const MEMBER_ROLE_COLORS: Partial<Record<DelegationRole, string>> = {
-  attendee_talking: "bg-blue-500 text-white",
-  attendee_listening: "bg-violet-500 text-white",
-  note_taker: "bg-amber-500 text-white",
-};
+import type { MeetingDetail, DelegationRole } from "@/lib/meetings/types";
+import { formatDate, formatTime, LINK_CN } from "@/lib/meetings/format";
+import { MEMBER_ROLES, ROLE_LABELS } from "@/lib/meetings/meeting-roles";
+import { MemberAvatar } from "@/components/meetings/member-avatar";
+import { AvatarInitialsCircle } from "@/components/ui/avatar-initials-circle";
 
 const SECTION_LABEL_CLASSNAME =
   "font-semibold uppercase tracking-wide text-muted-foreground";
-
-const MEMBER_ROLES: DelegationRole[] = [
-  "attendee_talking",
-  "attendee_listening",
-  "note_taker",
-];
-
-function MemberAvatar({ member }: { member: DelegationMember }) {
-  const [clicked, setClicked] = useState(false);
-  const [hovered, setHovered] = useState(false);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const colorClass =
-    MEMBER_ROLE_COLORS[member.role] ?? "bg-muted text-foreground";
-
-  useEffect(() => {
-    if (!clicked) return;
-    function handleClose(e: MouseEvent | KeyboardEvent) {
-      if (e instanceof KeyboardEvent) {
-        if (e.key === "Escape") setClicked(false);
-        return;
-      }
-      if (buttonRef.current && !buttonRef.current.contains(e.target as Node)) {
-        setClicked(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClose);
-    document.addEventListener("keydown", handleClose);
-    return () => {
-      document.removeEventListener("mousedown", handleClose);
-      document.removeEventListener("keydown", handleClose);
-    };
-  }, [clicked]);
-
-  return (
-    <TooltipProvider>
-      <Tooltip open={hovered || clicked}>
-        <TooltipTrigger asChild>
-          <button
-            ref={buttonRef}
-            type="button"
-            className="shrink-0 rounded-full"
-            onMouseEnter={() => setHovered(true)}
-            onMouseLeave={() => setHovered(false)}
-            onClick={() => setClicked((v) => !v)}
-            aria-label={`${member.display_name} — ${ROLE_LABELS[member.role]}`}
-          >
-            <MemberInitialsCircle
-              name={member.display_name}
-              colorClass={colorClass}
-            />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent
-          side="top"
-          className="max-w-48 bg-accent text-accent-foreground"
-          arrowClassName="bg-accent fill-accent"
-        >
-          <p className="text-sm font-bold">{ROLE_LABELS[member.role]}</p>
-          <p className="text-sm font-medium">{member.display_name}</p>
-          {member.email && (
-            <a
-              href={`mailto:${member.email}`}
-              className="text-sm italic underline-offset-4 hover:underline"
-            >
-              {member.email}
-            </a>
-          )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
 
 const CHAMPION_LABELS: Record<number, string> = {
   0: "Opposed",
@@ -124,30 +20,6 @@ const CHAMPION_LABELS: Record<number, string> = {
   4: "Advocate",
   5: "Champion",
 };
-
-function MemberInitialsCircle({
-  name,
-  colorClass = "bg-muted text-foreground",
-  size = "md",
-  ...props
-}: ComponentPropsWithoutRef<"span"> & {
-  name: string;
-  colorClass?: string;
-  size?: "sm" | "md";
-}) {
-  return (
-    <span
-      className={cn(
-        "flex shrink-0 items-center justify-center rounded-full text-xs font-semibold",
-        size === "sm" ? "h-7 w-7" : "h-8 w-8",
-        colorClass,
-      )}
-      {...props}
-    >
-      {initials(name)}
-    </span>
-  );
-}
 
 export function MeetingDetailView({
   meeting,
@@ -263,9 +135,8 @@ export function MeetingDetailView({
                           {ROLE_LABELS[m.role]}
                         </span>
                         <span className="flex items-center gap-2">
-                          <MemberInitialsCircle
+                          <AvatarInitialsCircle
                             name={m.display_name}
-                            size="sm"
                             aria-hidden="true"
                           />
                           <span className="min-w-0 flex-1">

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { ExternalLink, Settings } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { MeetingDetail, DelegationRole } from "@/lib/meetings/types";
+
+const ROLE_LABELS: Record<DelegationRole, string> = {
+  scheduling_lead: "Scheduling Lead",
+  attendee_talking: "Attendee (Talking)",
+  attendee_listening: "Attendee (Listening)",
+  pih_team_member: "PIH Team Member",
+  note_taker: "Note Taker",
+};
+
+const CHAMPION_LABELS: Record<number, string> = {
+  0: "Opposed",
+  1: "Skeptic",
+  2: "Neutral",
+  3: "Supporter",
+  4: "Advocate",
+  5: "Champion",
+};
+
+function initials(name: string): string {
+  return name
+    .split(" ")
+    .map((p) => p[0] ?? "")
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export function MeetingDetailView({
+  meeting,
+  onEdit,
+}: {
+  meeting: MeetingDetail;
+  onEdit: () => void;
+}) {
+  const pihMembers = meeting.delegation_members.filter(
+    (m) => m.role === "pih_team_member",
+  );
+
+  return (
+    <div className="border-t p-6">
+      <div className="flex items-start gap-4">
+        <div className="grid flex-1 gap-6 @[600px]:grid-cols-2">
+          <div className="flex flex-col gap-4">
+            {meeting.location && (
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Location
+                </p>
+                <p className="mt-1 text-sm">{meeting.location}</p>
+              </div>
+            )}
+            {meeting.notes && (
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Notes
+                </p>
+                <div className="mt-1 border-l-4 border-muted pl-3">
+                  <p className="text-sm">{meeting.notes}</p>
+                </div>
+              </div>
+            )}
+            {meeting.links.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Links
+                </p>
+                <ul className="mt-1 flex flex-col gap-1">
+                  {meeting.links.map((link, i) => (
+                    <li key={i}>
+                      <a
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-sm text-primary-dark underline-offset-4 hover:underline"
+                      >
+                        <ExternalLink
+                          aria-hidden="true"
+                          className="h-3 w-3 shrink-0"
+                        />
+                        {link.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Delegation
+              </p>
+              {meeting.delegation_members.length === 0 ? (
+                <p className="mt-1 text-sm text-muted-foreground">None</p>
+              ) : (
+                <ul className="mt-1 flex flex-col gap-2">
+                  {meeting.delegation_members.map((m) => (
+                    <li key={m.id} className="flex items-center gap-2">
+                      <span
+                        aria-hidden="true"
+                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
+                      >
+                        {initials(m.display_name)}
+                      </span>
+                      <span className="text-sm">{m.display_name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        — {ROLE_LABELS[m.role]}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {pihMembers.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  PIH Team Member
+                </p>
+                <ul className="mt-1 flex flex-col gap-1">
+                  {pihMembers.map((m) => (
+                    <li key={m.id} className="text-sm">
+                      {m.display_name}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {meeting.champion_score != null && (
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Champion Level
+                </p>
+                <p className="mt-1 text-sm">
+                  {meeting.champion_score} –{" "}
+                  {CHAMPION_LABELS[meeting.champion_score] ?? ""}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label="Edit meeting"
+          onClick={onEdit}
+          className="shrink-0"
+        >
+          <Settings aria-hidden="true" className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -29,6 +29,9 @@ const MEMBER_ROLE_COLORS: Partial<Record<DelegationRole, string>> = {
   note_taker: "bg-amber-500 text-white",
 };
 
+const SECTION_LABEL_CLASSNAME =
+  "font-semibold uppercase tracking-wide text-muted-foreground";
+
 const MEMBER_ROLES: DelegationRole[] = [
   "attendee_talking",
   "attendee_listening",
@@ -124,25 +127,7 @@ export function MeetingDetailView({
   onEdit?: () => void;
 }) {
   return (
-    <div className="relative p-6">
-      {onEdit && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                size="icon"
-                className="absolute right-4 top-4 h-8 w-8"
-                onClick={onEdit}
-                aria-label="Edit meeting"
-              >
-                <Pencil className="h-3.5 w-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Edit meeting</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      )}
+    <div className="p-4">
       <div className="grid gap-6 @[600px]:grid-cols-2">
         <div className="flex flex-col gap-4">
           {(() => {
@@ -155,9 +140,7 @@ export function MeetingDetailView({
               <div className="flex gap-6">
                 {showChampion && (
                   <div>
-                    <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
-                      Champion Level
-                    </p>
+                    <p className={SECTION_LABEL_CLASSNAME}>Champion Level</p>
                     <p className="mt-1 text-sm">
                       {meeting.champion_score != null
                         ? `${meeting.champion_score} – ${CHAMPION_LABELS[meeting.champion_score] ?? "Unknown"}`
@@ -167,9 +150,7 @@ export function MeetingDetailView({
                 )}
                 {showFollowUp && (
                   <div>
-                    <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
-                      Follow-up
-                    </p>
+                    <p className={SECTION_LABEL_CLASSNAME}>Follow-up</p>
                     <p className="mt-1 text-sm">
                       {meeting.follow_up_date
                         ? new Date(
@@ -188,9 +169,7 @@ export function MeetingDetailView({
           })()}
           {meeting.notes && (
             <div>
-              <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
-                Notes
-              </p>
+              <p className={SECTION_LABEL_CLASSNAME}>Notes</p>
               <div className="mt-1 border-l-4 border-muted pl-3">
                 <p className="text-sm">{meeting.notes}</p>
               </div>
@@ -198,9 +177,7 @@ export function MeetingDetailView({
           )}
           {meeting.links.length > 0 && (
             <div>
-              <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
-                Links
-              </p>
+              <p className={SECTION_LABEL_CLASSNAME}>Links</p>
               <ul className="mt-1 flex flex-col gap-1">
                 {meeting.links.map((link) => (
                   <li key={`${link.label}::${link.url}`}>
@@ -226,16 +203,12 @@ export function MeetingDetailView({
         <div className="flex flex-col gap-4">
           {meeting.location && (
             <div>
-              <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
-                Location
-              </p>
+              <p className={SECTION_LABEL_CLASSNAME}>Location</p>
               <p className="mt-1 text-sm">{meeting.location}</p>
             </div>
           )}
           <div>
-            <p className="text-[0.8rem] font-semibold uppercase tracking-wide text-muted-foreground">
-              Delegation
-            </p>
+            <p className={SECTION_LABEL_CLASSNAME}>Delegation</p>
             {meeting.delegation_members.length === 0 ? (
               <p className="mt-1 text-sm text-muted-foreground">None</p>
             ) : (
@@ -247,7 +220,7 @@ export function MeetingDetailView({
                     .filter((m) => m.role === role)
                     .map((m) => (
                       <div key={m.id} className="flex flex-col gap-0.5">
-                        <span className="text-xs text-muted-foreground">
+                        <span className="text-sm text-muted-foreground">
                           {ROLE_LABELS[m.role]}
                         </span>
                         <span className="flex items-center gap-2">
@@ -281,7 +254,7 @@ export function MeetingDetailView({
                   if (attendees.length === 0) return null;
                   return (
                     <div className="flex flex-col gap-1">
-                      <span className="text-xs text-muted-foreground">
+                      <span className="text-sm text-muted-foreground">
                         Attendees
                       </span>
                       <div className="flex flex-wrap gap-1.5">
@@ -295,6 +268,14 @@ export function MeetingDetailView({
               </div>
             )}
           </div>
+          {onEdit && (
+            <div className="mt-auto pt-2">
+              <Button variant="outline" onClick={onEdit}>
+                <Pencil className="h-3.5 w-3.5" />
+                Edit Meeting
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -3,7 +3,11 @@
 import { cn } from "@/lib/utils";
 import { ExternalLink, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import type { MeetingDetail, DelegationRole } from "@/lib/meetings/types";
+import type {
+  MeetingDetail,
+  DelegationMember,
+  DelegationRole,
+} from "@/lib/meetings/types";
 import { formatDate, formatTime, LINK_CN } from "@/lib/meetings/format";
 import { MEMBER_ROLES, ROLE_LABELS } from "@/lib/meetings/meeting-roles";
 import { MemberAvatar } from "@/components/meetings/member-avatar";
@@ -21,6 +25,30 @@ const CHAMPION_LABELS: Record<number, string> = {
   5: "Champion",
 };
 
+function DelegationMemberRow({ member }: { member: DelegationMember }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-sm text-muted-foreground">
+        {ROLE_LABELS[member.role]}
+      </span>
+      <span className="flex items-center gap-2">
+        <AvatarInitialsCircle name={member.display_name} aria-hidden="true" />
+        <span className="min-w-0 flex-1">
+          <span className="text-sm font-medium">{member.display_name}</span>
+          {member.email && (
+            <a
+              href={`mailto:${member.email}`}
+              className="ml-1.5 text-xs text-muted-foreground underline-offset-4 hover:underline"
+            >
+              {member.email}
+            </a>
+          )}
+        </span>
+      </span>
+    </div>
+  );
+}
+
 export function MeetingDetailView({
   meeting,
   onEdit,
@@ -28,41 +56,38 @@ export function MeetingDetailView({
   meeting: MeetingDetail;
   onEdit?: () => void;
 }) {
+  const isPast = meeting.meeting_date < new Date().toISOString().slice(0, 10);
+  const showChampion = isPast || meeting.champion_score != null;
+  const showFollowUp = isPast || meeting.follow_up_date != null;
+
   return (
     <div className="p-4">
       <div className="grid gap-6 @[600px]:grid-cols-2">
         <div className="flex flex-col gap-4">
-          {(() => {
-            const isPast =
-              meeting.meeting_date < new Date().toISOString().slice(0, 10);
-            const showChampion = isPast || meeting.champion_score != null;
-            const showFollowUp = isPast || meeting.follow_up_date != null;
-            if (!showChampion && !showFollowUp) return null;
-            return (
-              <div className="flex gap-6">
-                {showChampion && (
-                  <div>
-                    <p className={SECTION_LABEL_CLASSNAME}>Champion Level</p>
-                    <p className="mt-1 text-sm">
-                      {meeting.champion_score != null
-                        ? `${meeting.champion_score} – ${CHAMPION_LABELS[meeting.champion_score] ?? "Unknown"}`
-                        : "—"}
-                    </p>
-                  </div>
-                )}
-                {showFollowUp && (
-                  <div>
-                    <p className={SECTION_LABEL_CLASSNAME}>Follow-up</p>
-                    <p className="mt-1 text-sm">
-                      {meeting.follow_up_date
-                        ? formatDate(meeting.follow_up_date)
-                        : "—"}
-                    </p>
-                  </div>
-                )}
-              </div>
-            );
-          })()}
+          {(showChampion || showFollowUp) && (
+            <div className="flex gap-6">
+              {showChampion && (
+                <div>
+                  <p className={SECTION_LABEL_CLASSNAME}>Champion Level</p>
+                  <p className="mt-1 text-sm">
+                    {meeting.champion_score != null
+                      ? `${meeting.champion_score} – ${CHAMPION_LABELS[meeting.champion_score] ?? "Unknown"}`
+                      : "—"}
+                  </p>
+                </div>
+              )}
+              {showFollowUp && (
+                <div>
+                  <p className={SECTION_LABEL_CLASSNAME}>Follow-up</p>
+                  <p className="mt-1 text-sm">
+                    {meeting.follow_up_date
+                      ? formatDate(meeting.follow_up_date)
+                      : "—"}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
           {meeting.notes && (
             <div>
               <p className={SECTION_LABEL_CLASSNAME}>Notes</p>
@@ -129,32 +154,7 @@ export function MeetingDetailView({
                 ).flatMap((role) =>
                   meeting.delegation_members
                     .filter((m) => m.role === role)
-                    .map((m) => (
-                      <div key={m.id} className="flex flex-col gap-0.5">
-                        <span className="text-sm text-muted-foreground">
-                          {ROLE_LABELS[m.role]}
-                        </span>
-                        <span className="flex items-center gap-2">
-                          <AvatarInitialsCircle
-                            name={m.display_name}
-                            aria-hidden="true"
-                          />
-                          <span className="min-w-0 flex-1">
-                            <span className="text-sm font-medium">
-                              {m.display_name}
-                            </span>
-                            {m.email && (
-                              <a
-                                href={`mailto:${m.email}`}
-                                className="ml-1.5 text-xs text-muted-foreground underline-offset-4 hover:underline"
-                              >
-                                {m.email}
-                              </a>
-                            )}
-                          </span>
-                        </span>
-                      </div>
-                    )),
+                    .map((m) => <DelegationMemberRow key={m.id} member={m} />),
                 )}
                 {(() => {
                   const attendees = meeting.delegation_members

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -18,10 +18,10 @@ const SECTION_LABEL_CLASSNAME =
 
 const CHAMPION_LABELS: Record<number, string> = {
   0: "Opposed",
-  1: "Skeptic",
-  2: "Neutral",
-  3: "Supporter",
-  4: "Advocate",
+  1: "Neutral/Uninformed",
+  2: "Supporter",
+  3: "Advocate",
+  4: "Leader",
   5: "Champion",
 };
 

--- a/components/meetings/meeting-detail-view.tsx
+++ b/components/meetings/meeting-detail-view.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  type ComponentPropsWithoutRef,
+} from "react";
+import { cn } from "@/lib/utils";
 import { ExternalLink, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,7 +20,12 @@ import type {
   DelegationMember,
   DelegationRole,
 } from "@/lib/meetings/types";
-import { formatTime } from "@/lib/meetings/format";
+import {
+  formatDate,
+  formatTime,
+  initials,
+  LINK_CN,
+} from "@/lib/meetings/format";
 
 const ROLE_LABELS: Record<DelegationRole, string> = {
   scheduling_lead: "Scheduling Lead",
@@ -72,13 +83,16 @@ function MemberAvatar({ member }: { member: DelegationMember }) {
           <button
             ref={buttonRef}
             type="button"
-            className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${colorClass}`}
+            className="shrink-0 rounded-full"
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
             onClick={() => setClicked((v) => !v)}
             aria-label={`${member.display_name} — ${ROLE_LABELS[member.role]}`}
           >
-            {initials(member.display_name)}
+            <MemberInitialsCircle
+              name={member.display_name}
+              colorClass={colorClass}
+            />
           </button>
         </TooltipTrigger>
         <TooltipContent
@@ -111,13 +125,28 @@ const CHAMPION_LABELS: Record<number, string> = {
   5: "Champion",
 };
 
-function initials(name: string): string {
-  return name
-    .split(" ")
-    .map((p) => p[0] ?? "")
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
+function MemberInitialsCircle({
+  name,
+  colorClass = "bg-muted text-foreground",
+  size = "md",
+  ...props
+}: ComponentPropsWithoutRef<"span"> & {
+  name: string;
+  colorClass?: string;
+  size?: "sm" | "md";
+}) {
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-full text-xs font-semibold",
+        size === "sm" ? "h-7 w-7" : "h-8 w-8",
+        colorClass,
+      )}
+      {...props}
+    >
+      {initials(name)}
+    </span>
+  );
 }
 
 export function MeetingDetailView({
@@ -154,13 +183,7 @@ export function MeetingDetailView({
                     <p className={SECTION_LABEL_CLASSNAME}>Follow-up</p>
                     <p className="mt-1 text-sm">
                       {meeting.follow_up_date
-                        ? new Date(
-                            meeting.follow_up_date + "T00:00:00",
-                          ).toLocaleDateString("en-US", {
-                            month: "short",
-                            day: "numeric",
-                            year: "numeric",
-                          })
+                        ? formatDate(meeting.follow_up_date)
                         : "—"}
                     </p>
                   </div>
@@ -186,7 +209,10 @@ export function MeetingDetailView({
                       href={link.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-sm text-primary-dark underline-offset-4 hover:underline"
+                      className={cn(
+                        "inline-flex items-center gap-1 text-sm",
+                        LINK_CN,
+                      )}
                     >
                       <ExternalLink
                         aria-hidden="true"
@@ -237,12 +263,11 @@ export function MeetingDetailView({
                           {ROLE_LABELS[m.role]}
                         </span>
                         <span className="flex items-center gap-2">
-                          <span
+                          <MemberInitialsCircle
+                            name={m.display_name}
+                            size="sm"
                             aria-hidden="true"
-                            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold"
-                          >
-                            {initials(m.display_name)}
-                          </span>
+                          />
                           <span className="min-w-0 flex-1">
                             <span className="text-sm font-medium">
                               {m.display_name}

--- a/components/meetings/meeting-detail.tsx
+++ b/components/meetings/meeting-detail.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { fetchMeetingDetail } from "@/lib/meetings/queries";
+import type {
+  MeetingRow,
+  MeetingDetail as MeetingDetailType,
+} from "@/lib/meetings/types";
+import { MeetingDetailView } from "@/components/meetings/meeting-detail-view";
+
+export function MeetingDetail({ meeting }: { meeting: MeetingRow }) {
+  const [detail, setDetail] = useState<MeetingDetailType | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+    setIsLoading(true);
+    setLoadError(null);
+
+    fetchMeetingDetail(supabase, meeting.id)
+      .then((d) => {
+        if (cancelled) return;
+        setDetail(d);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setLoadError(
+          err instanceof Error ? err.message : "Failed to load meeting details",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [meeting.id]);
+
+  if (isLoading)
+    return (
+      <div className="border-t p-6 text-sm text-muted-foreground">Loading…</div>
+    );
+  if (loadError)
+    return (
+      <div className="border-t p-6 text-sm text-destructive">{loadError}</div>
+    );
+  if (!detail) return null;
+
+  return <MeetingDetailView meeting={detail} onEdit={() => {}} />;
+}

--- a/components/meetings/meeting-detail.tsx
+++ b/components/meetings/meeting-detail.tsx
@@ -50,5 +50,5 @@ export function MeetingDetail({ meeting }: { meeting: MeetingRow }) {
     );
   if (!detail) return null;
 
-  return <MeetingDetailView meeting={detail} />;
+  return <MeetingDetailView meeting={detail} onEdit={() => {}} />;
 }

--- a/components/meetings/meeting-detail.tsx
+++ b/components/meetings/meeting-detail.tsx
@@ -50,5 +50,5 @@ export function MeetingDetail({ meeting }: { meeting: MeetingRow }) {
     );
   if (!detail) return null;
 
-  return <MeetingDetailView meeting={detail} onEdit={() => {}} />;
+  return <MeetingDetailView meeting={detail} />;
 }

--- a/components/meetings/meeting-row.tsx
+++ b/components/meetings/meeting-row.tsx
@@ -6,16 +6,8 @@ import { ChevronDown, ChevronRight, CircleCheckBig } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { MeetingRow as MeetingRowType } from "@/lib/meetings/types";
-import { formatTime } from "@/lib/meetings/format";
+import { formatDate, formatTime, LINK_CN } from "@/lib/meetings/format";
 import { MeetingDetail } from "@/components/meetings/meeting-detail";
-
-function formatDate(isoDate: string): string {
-  return new Date(`${isoDate}T00:00:00`).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
 
 export function MeetingRow({
   meeting,
@@ -25,14 +17,10 @@ export function MeetingRow({
   isPast?: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [hasExpanded, setHasExpanded] = useState(false);
   const colSpan = isPast ? 8 : 7;
   const detailRowId = `meeting-detail-${meeting.id}`;
 
-  const toggle = () => {
-    setHasExpanded(true);
-    setIsExpanded((v) => !v);
-  };
+  const toggle = () => setIsExpanded((v) => !v);
 
   return (
     <>
@@ -73,7 +61,7 @@ export function MeetingRow({
           <div className="truncate">
             <Link
               href={`/representatives/${meeting.representative_bioguide_id}`}
-              className="text-primary-dark underline-offset-4 hover:underline"
+              className={LINK_CN}
               onClick={(e) => e.stopPropagation()}
             >
               {meeting.representative_district === null ? "Sen. " : "Rep. "}
@@ -98,7 +86,7 @@ export function MeetingRow({
           {meeting.primary_team_slug ? (
             <Link
               href={`/teams/${meeting.primary_team_slug}`}
-              className="block truncate text-primary-dark underline-offset-4 hover:underline"
+              className={`block truncate ${LINK_CN}`}
               onClick={(e) => e.stopPropagation()}
             >
               {meeting.primary_team_name}
@@ -122,17 +110,16 @@ export function MeetingRow({
           </TableCell>
         )}
       </TableRow>
-      {hasExpanded && (
-        <TableRow
-          id={detailRowId}
-          className="hover:bg-background"
-          hidden={!isExpanded}
-        >
+      <TableRow
+        id={detailRowId}
+        className={isExpanded ? "hover:bg-background" : "hidden"}
+      >
+        {isExpanded && (
           <TableCell colSpan={colSpan} className="whitespace-normal p-0">
             <MeetingDetail meeting={meeting} />
           </TableCell>
-        </TableRow>
-      )}
+        )}
+      </TableRow>
     </>
   );
 }

--- a/components/meetings/meeting-row.tsx
+++ b/components/meetings/meeting-row.tsx
@@ -37,7 +37,7 @@ export function MeetingRow({
   return (
     <>
       <TableRow
-        className={`has-aria-expanded:bg-accent cursor-pointer hover:bg-accent${isExpanded ? "bg-accent" : ""}`}
+        className={`cursor-pointer hover:bg-accent${isExpanded ? "bg-accent" : ""}`}
         onClick={toggle}
       >
         <TableCell>

--- a/components/meetings/meeting-row.tsx
+++ b/components/meetings/meeting-row.tsx
@@ -6,6 +6,7 @@ import { ChevronDown, ChevronRight, CircleCheckBig } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { MeetingRow as MeetingRowType } from "@/lib/meetings/types";
+import { MeetingDetail } from "@/components/meetings/meeting-detail";
 
 function formatDate(isoDate: string): string {
   return new Date(`${isoDate}T00:00:00`).toLocaleDateString("en-US", {
@@ -48,83 +49,99 @@ export function MeetingRow({
   isPast?: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const colSpan = isPast ? 8 : 7;
+  const detailRowId = `meeting-detail-${meeting.id}`;
 
   return (
-    <TableRow>
-      <TableCell>
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label={`Expand meeting with ${meeting.representative_name}`}
-          aria-expanded={isExpanded}
-          onClick={() => setIsExpanded((v) => !v)}
-        >
-          {isExpanded ? (
-            <ChevronDown aria-hidden="true" className={`h-4 w-4`} />
-          ) : (
-            <ChevronRight aria-hidden="true" className={`h-4 w-4`} />
-          )}
-        </Button>
-      </TableCell>
-      <TableCell>{formatDate(meeting.meeting_date)}</TableCell>
-      <TableCell>
-        {meeting.meeting_time
-          ? formatTime(
-              meeting.meeting_date,
-              meeting.meeting_time,
-              meeting.meeting_timezone,
-            )
-          : "—"}
-      </TableCell>
-      <TableCell className="max-w-0">
-        <div className="truncate">
-          <Link
-            href={`/representatives/${meeting.representative_bioguide_id}`}
-            className="text-primary-dark underline-offset-4 hover:underline"
+    <>
+      <TableRow
+        className={`cursor-pointer ${isExpanded ? "bg-accent hover:bg-accent" : "hover:bg-accent"}`}
+        onClick={() => setIsExpanded((v) => !v)}
+      >
+        <TableCell>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={`Expand meeting with ${meeting.representative_name}`}
+            aria-expanded={isExpanded}
+            aria-controls={detailRowId}
           >
-            {meeting.representative_district === null ? "Sen. " : "Rep. "}
-            {meeting.representative_name}
-          </Link>{" "}
-          — {meeting.representative_state} (
-          {meeting.representative_party[0] ?? "?"})
-        </div>
-      </TableCell>
-      <TableCell className="max-w-0 truncate">
-        {meeting.congressional_contact_id === null ? (
-          <em>
-            {meeting.representative_district === null
-              ? "Senator"
-              : "Congressperson"}
-          </em>
-        ) : (
-          meeting.congressional_contact_name
-        )}
-      </TableCell>
-      <TableCell className="max-w-0">
-        {meeting.primary_team_slug ? (
-          <Link
-            href={`/teams/${meeting.primary_team_slug}`}
-            className="block truncate text-primary-dark underline-offset-4 hover:underline"
-          >
-            {meeting.primary_team_name}
-          </Link>
-        ) : (
-          "—"
-        )}
-      </TableCell>
-      <TableCell className="max-w-0 truncate">
-        {meeting.scheduling_lead_name ?? "—"}
-      </TableCell>
-      {isPast && (
-        <TableCell className="text-center">
-          {meeting.follow_up_date ? (
-            <CircleCheckBig
-              aria-label="Follow-up sent"
-              className="m-auto h-4 w-4 text-green-600"
-            />
-          ) : null}
+            {isExpanded ? (
+              <ChevronDown aria-hidden="true" className={`h-4 w-4`} />
+            ) : (
+              <ChevronRight aria-hidden="true" className={`h-4 w-4`} />
+            )}
+          </Button>
         </TableCell>
+        <TableCell>{formatDate(meeting.meeting_date)}</TableCell>
+        <TableCell>
+          {meeting.meeting_time
+            ? formatTime(
+                meeting.meeting_date,
+                meeting.meeting_time,
+                meeting.meeting_timezone,
+              )
+            : "—"}
+        </TableCell>
+        <TableCell className="max-w-0">
+          <div className="truncate">
+            <Link
+              href={`/representatives/${meeting.representative_bioguide_id}`}
+              className="text-primary-dark underline-offset-4 hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {meeting.representative_district === null ? "Sen. " : "Rep. "}
+              {meeting.representative_name}
+            </Link>{" "}
+            — {meeting.representative_state} (
+            {meeting.representative_party[0] ?? "?"})
+          </div>
+        </TableCell>
+        <TableCell className="max-w-0 truncate">
+          {meeting.congressional_contact_id === null ? (
+            <em>
+              {meeting.representative_district === null
+                ? "Senator"
+                : "Congressperson"}
+            </em>
+          ) : (
+            meeting.congressional_contact_name
+          )}
+        </TableCell>
+        <TableCell className="max-w-0">
+          {meeting.primary_team_slug ? (
+            <Link
+              href={`/teams/${meeting.primary_team_slug}`}
+              className="block truncate text-primary-dark underline-offset-4 hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {meeting.primary_team_name}
+            </Link>
+          ) : (
+            "—"
+          )}
+        </TableCell>
+        <TableCell className="max-w-0 truncate">
+          {meeting.scheduling_lead_name ?? "—"}
+        </TableCell>
+        {isPast && (
+          <TableCell className="text-center">
+            {meeting.follow_up_date ? (
+              <CircleCheckBig
+                aria-label="Follow-up sent"
+                className="m-auto h-4 w-4 text-green-600"
+              />
+            ) : null}
+          </TableCell>
+        )}
+      </TableRow>
+      {isExpanded && (
+        <TableRow id={detailRowId} className="hover:bg-background">
+          <TableCell colSpan={colSpan} className="p-0">
+            <MeetingDetail meeting={meeting} />
+          </TableCell>
+        </TableRow>
       )}
-    </TableRow>
+    </>
   );
 }

--- a/components/meetings/meeting-row.tsx
+++ b/components/meetings/meeting-row.tsx
@@ -6,6 +6,7 @@ import { ChevronDown, ChevronRight, CircleCheckBig } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { MeetingRow as MeetingRowType } from "@/lib/meetings/types";
+import { formatTime } from "@/lib/meetings/format";
 import { MeetingDetail } from "@/components/meetings/meeting-detail";
 
 function formatDate(isoDate: string): string {
@@ -16,31 +17,6 @@ function formatDate(isoDate: string): string {
   });
 }
 
-function formatTime(
-  meetingDate: string,
-  time: string,
-  timezone: string,
-): string {
-  const [h, m] = time.split(":").map(Number);
-  const hour12 = h % 12 || 12;
-  const ampm = h < 12 ? "AM" : "PM";
-  const minuteStr = m.toString().padStart(2, "0");
-  let tzAbbr = "";
-  try {
-    const refDate = new Date(`${meetingDate}T12:00:00Z`);
-    tzAbbr =
-      new Intl.DateTimeFormat("en-US", {
-        timeZone: timezone,
-        timeZoneName: "short",
-      })
-        .formatToParts(refDate)
-        .find((p) => p.type === "timeZoneName")?.value ?? "";
-  } catch {}
-  return tzAbbr
-    ? `${hour12}:${minuteStr} ${ampm} ${tzAbbr}`
-    : `${hour12}:${minuteStr} ${ampm}`;
-}
-
 export function MeetingRow({
   meeting,
   isPast = false,
@@ -49,14 +25,20 @@ export function MeetingRow({
   isPast?: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [hasExpanded, setHasExpanded] = useState(false);
   const colSpan = isPast ? 8 : 7;
   const detailRowId = `meeting-detail-${meeting.id}`;
+
+  const toggle = () => {
+    setHasExpanded(true);
+    setIsExpanded((v) => !v);
+  };
 
   return (
     <>
       <TableRow
-        className={`cursor-pointer ${isExpanded ? "bg-accent hover:bg-accent" : "hover:bg-accent"}`}
-        onClick={() => setIsExpanded((v) => !v)}
+        className={`has-aria-expanded:bg-accent cursor-pointer hover:bg-accent${isExpanded ? "bg-accent" : ""}`}
+        onClick={toggle}
       >
         <TableCell>
           <Button
@@ -65,6 +47,10 @@ export function MeetingRow({
             aria-label={`Expand meeting with ${meeting.representative_name}`}
             aria-expanded={isExpanded}
             aria-controls={detailRowId}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggle();
+            }}
           >
             {isExpanded ? (
               <ChevronDown aria-hidden="true" className={`h-4 w-4`} />
@@ -128,6 +114,7 @@ export function MeetingRow({
           <TableCell className="text-center">
             {meeting.follow_up_date ? (
               <CircleCheckBig
+                role="img"
                 aria-label="Follow-up sent"
                 className="m-auto h-4 w-4 text-green-600"
               />
@@ -135,9 +122,13 @@ export function MeetingRow({
           </TableCell>
         )}
       </TableRow>
-      {isExpanded && (
-        <TableRow id={detailRowId} className="hover:bg-background">
-          <TableCell colSpan={colSpan} className="p-0">
+      {hasExpanded && (
+        <TableRow
+          id={detailRowId}
+          className="hover:bg-background"
+          hidden={!isExpanded}
+        >
+          <TableCell colSpan={colSpan} className="whitespace-normal p-0">
             <MeetingDetail meeting={meeting} />
           </TableCell>
         </TableRow>

--- a/components/meetings/meeting-row.tsx
+++ b/components/meetings/meeting-row.tsx
@@ -37,7 +37,7 @@ export function MeetingRow({
   return (
     <>
       <TableRow
-        className={`cursor-pointer hover:bg-accent${isExpanded ? "bg-accent" : ""}`}
+        className={`cursor-pointer hover:bg-accent ${isExpanded ? "bg-accent" : ""}`}
         onClick={toggle}
       >
         <TableCell>

--- a/components/meetings/member-avatar.tsx
+++ b/components/meetings/member-avatar.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { DelegationMember } from "@/lib/meetings/types";
+import { ROLE_COLORS, ROLE_LABELS } from "@/lib/meetings/meeting-roles";
+import { AvatarInitialsCircle } from "@/components/ui/avatar-initials-circle";
+
+export function MemberAvatar({ member }: { member: DelegationMember }) {
+  const [clicked, setClicked] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const colorClass = ROLE_COLORS[member.role];
+
+  useEffect(() => {
+    if (!clicked) return;
+    function handleClose(e: MouseEvent | KeyboardEvent) {
+      if (e instanceof KeyboardEvent) {
+        if (e.key === "Escape") setClicked(false);
+        return;
+      }
+      if (buttonRef.current && !buttonRef.current.contains(e.target as Node)) {
+        setClicked(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClose);
+    document.addEventListener("keydown", handleClose);
+    return () => {
+      document.removeEventListener("mousedown", handleClose);
+      document.removeEventListener("keydown", handleClose);
+    };
+  }, [clicked]);
+
+  return (
+    <TooltipProvider>
+      <Tooltip open={hovered || clicked}>
+        <TooltipTrigger asChild>
+          <button
+            ref={buttonRef}
+            type="button"
+            className="shrink-0 rounded-full"
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+            onClick={() => setClicked((v) => !v)}
+            aria-label={`${member.display_name} — ${ROLE_LABELS[member.role]}`}
+          >
+            <AvatarInitialsCircle
+              name={member.display_name}
+              colorClass={colorClass}
+            />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className="max-w-48 bg-accent text-accent-foreground"
+          arrowClassName="bg-accent fill-accent"
+        >
+          <p className="text-sm font-bold">{ROLE_LABELS[member.role]}</p>
+          <p className="text-sm font-medium">{member.display_name}</p>
+          {member.email && (
+            <a
+              href={`mailto:${member.email}`}
+              className="text-sm italic underline-offset-4 hover:underline"
+            >
+              {member.email}
+            </a>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/components/meetings/member-avatar.tsx
+++ b/components/meetings/member-avatar.tsx
@@ -50,7 +50,8 @@ export function MemberAvatar({ member }: { member: DelegationMember }) {
             aria-label={`${member.display_name} — ${ROLE_LABELS[member.role]}`}
           >
             <AvatarInitialsCircle
-              name={member.display_name}
+              firstName={member.first_name}
+              lastName={member.last_name}
               colorClass={colorClass}
             />
           </button>

--- a/components/ui/avatar-initials-circle.tsx
+++ b/components/ui/avatar-initials-circle.tsx
@@ -3,11 +3,13 @@ import { cn } from "@/lib/utils";
 import { initials } from "@/lib/meetings/format";
 
 export function AvatarInitialsCircle({
-  name,
+  firstName,
+  lastName,
   colorClass = "bg-muted text-foreground",
   ...props
 }: ComponentPropsWithoutRef<"span"> & {
-  name: string;
+  firstName: string;
+  lastName: string;
   colorClass?: string;
   size?: "sm" | "md";
 }) {
@@ -20,7 +22,7 @@ export function AvatarInitialsCircle({
       )}
       {...props}
     >
-      {initials(name)}
+      {initials(firstName, lastName)}
     </span>
   );
 }

--- a/components/ui/avatar-initials-circle.tsx
+++ b/components/ui/avatar-initials-circle.tsx
@@ -1,0 +1,26 @@
+import { type ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+import { initials } from "@/lib/meetings/format";
+
+export function AvatarInitialsCircle({
+  name,
+  colorClass = "bg-muted text-foreground",
+  ...props
+}: ComponentPropsWithoutRef<"span"> & {
+  name: string;
+  colorClass?: string;
+  size?: "sm" | "md";
+}) {
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-full text-xs font-semibold",
+        "h-8 w-8",
+        colorClass,
+      )}
+      {...props}
+    >
+      {initials(name)}
+    </span>
+  );
+}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -6,7 +6,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto rounded-md border @container"
+      className="relative w-full overflow-x-auto rounded-md border"
     >
       <table
         data-slot="table"

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -6,7 +6,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto rounded-md border"
+      className="relative w-full overflow-x-auto rounded-md border @container"
     >
       <table
         data-slot="table"

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -32,10 +32,13 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
+  arrowClassName,
   sideOffset = 0,
   children,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Content> & {
+  arrowClassName?: string;
+}) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -48,7 +51,12 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+        <TooltipPrimitive.Arrow
+          className={cn(
+            "z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground",
+            arrowClassName,
+          )}
+        />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/lib/meetings/format.ts
+++ b/lib/meetings/format.ts
@@ -6,13 +6,8 @@ export function formatDate(isoDate: string): string {
   });
 }
 
-export function initials(name: string): string {
-  return name
-    .split(" ")
-    .map((p) => p[0] ?? "")
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
+export function initials(firstName: string, lastName: string): string {
+  return ((firstName[0] ?? "") + (lastName[0] ?? "")).toUpperCase();
 }
 
 export const LINK_CN = "text-primary-dark underline-offset-4 hover:underline";

--- a/lib/meetings/format.ts
+++ b/lib/meetings/format.ts
@@ -1,0 +1,25 @@
+export function formatTime(
+  meetingDate: string,
+  time: string | null,
+  timezone: string,
+): string {
+  if (!time) return "";
+  const [h, m] = time.split(":").map(Number);
+  const hour12 = h % 12 || 12;
+  const ampm = h < 12 ? "AM" : "PM";
+  const minuteStr = m.toString().padStart(2, "0");
+  let tzAbbr = "";
+  try {
+    const refDate = new Date(`${meetingDate}T12:00:00Z`);
+    tzAbbr =
+      new Intl.DateTimeFormat("en-US", {
+        timeZone: timezone,
+        timeZoneName: "short",
+      })
+        .formatToParts(refDate)
+        .find((p) => p.type === "timeZoneName")?.value ?? "";
+  } catch {}
+  return tzAbbr
+    ? `${hour12}:${minuteStr} ${ampm} ${tzAbbr}`
+    : `${hour12}:${minuteStr} ${ampm}`;
+}

--- a/lib/meetings/format.ts
+++ b/lib/meetings/format.ts
@@ -1,3 +1,22 @@
+export function formatDate(isoDate: string): string {
+  return new Date(`${isoDate}T00:00:00`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function initials(name: string): string {
+  return name
+    .split(" ")
+    .map((p) => p[0] ?? "")
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export const LINK_CN = "text-primary-dark underline-offset-4 hover:underline";
+
 export function formatTime(
   meetingDate: string,
   time: string | null,

--- a/lib/meetings/meeting-roles.ts
+++ b/lib/meetings/meeting-roles.ts
@@ -1,0 +1,21 @@
+import type { DelegationRole } from "@/lib/meetings/types";
+
+export const ROLE_LABELS: Record<DelegationRole, string> = {
+  scheduling_lead: "Scheduling Lead",
+  attendee_talking: "Attendee (Talking)",
+  attendee_listening: "Attendee (Listening)",
+  pih_team_member: "PIH Team Member",
+  note_taker: "Note Taker",
+};
+
+export const ROLE_COLORS: Record<DelegationRole, string> = {
+  scheduling_lead: "bg-muted text-foreground",
+  attendee_talking: "bg-blue-500 text-white",
+  attendee_listening: "bg-violet-500 text-white",
+  pih_team_member: "bg-muted text-foreground",
+  note_taker: "bg-amber-500 text-white",
+};
+
+export const MEMBER_ROLES: DelegationRole[] = (
+  Object.keys(ROLE_LABELS) as DelegationRole[]
+).filter((r) => r !== "scheduling_lead" && r !== "pih_team_member");

--- a/lib/meetings/queries.ts
+++ b/lib/meetings/queries.ts
@@ -222,7 +222,7 @@ type RawDetailDelegationMember = {
   profiles: {
     first_name: string | null;
     last_name: string | null;
-    email: string;
+    email: string | null;
   } | null;
 };
 

--- a/lib/meetings/queries.ts
+++ b/lib/meetings/queries.ts
@@ -269,6 +269,8 @@ export async function fetchMeetingDetail(
     row.meeting_delegation_members.map((m) => ({
       id: m.id,
       user_id: m.user_id,
+      first_name: m.profiles?.first_name ?? "",
+      last_name: m.profiles?.last_name ?? "",
       display_name: m.profiles
         ? [m.profiles.first_name, m.profiles.last_name]
             .filter(Boolean)

--- a/lib/meetings/queries.ts
+++ b/lib/meetings/queries.ts
@@ -4,6 +4,10 @@ import {
   CreateMeetingValues,
   LinkFormEntry,
   MeetingRow,
+  MeetingDetail,
+  MeetingLink,
+  DelegationMember,
+  DelegationRole,
 } from "@/lib/meetings/types";
 import { localDateString } from "@/lib/utils";
 import { ORG_ID } from "@/lib/org";
@@ -207,4 +211,84 @@ export async function createMeeting(
   }
 
   return data.id;
+}
+
+type RawDetailDelegationMember = {
+  id: string;
+  user_id: string;
+  role: string;
+  team_id: string | null;
+  team_name_snapshot: string | null;
+  profiles: { first_name: string | null; last_name: string | null } | null;
+};
+
+type RawDetailRow = Omit<RawRow, "meeting_delegation_members"> & {
+  notes: string | null;
+  location: string | null;
+  links: MeetingLink[] | null;
+  meeting_delegation_members: RawDetailDelegationMember[];
+};
+
+const SELECT_DETAIL = `
+  id,
+  meeting_date,
+  meeting_time,
+  meeting_timezone,
+  representative_id,
+  congressional_contact_id,
+  primary_team_id,
+  follow_up_date,
+  champion_score,
+  notes,
+  location,
+  links,
+  representatives!inner ( bioguide_id, official_full_name, state, district, party ),
+  staffers ( first_name, last_name ),
+  teams ( name, slug ),
+  meeting_delegation_members ( id, user_id, role, team_id, team_name_snapshot, profiles ( first_name, last_name ) )
+`;
+
+export async function fetchMeetingDetail(
+  supabase: SupabaseBrowserClient,
+  id: string,
+): Promise<MeetingDetail> {
+  const { data, error } = await supabase
+    .from("meetings")
+    .select(SELECT_DETAIL)
+    .eq("id", id)
+    .single();
+
+  if (error) throw error;
+  const row = data as unknown as RawDetailRow;
+
+  const delegation_members: DelegationMember[] =
+    row.meeting_delegation_members.map((m) => ({
+      id: m.id,
+      user_id: m.user_id,
+      display_name: m.profiles
+        ? [m.profiles.first_name, m.profiles.last_name]
+            .filter(Boolean)
+            .join(" ") || "Anonymous"
+        : "Anonymous",
+      role: m.role as DelegationRole,
+      team_id: m.team_id,
+      team_name_snapshot: m.team_name_snapshot,
+    }));
+
+  const represented_teams = [
+    ...new Set(
+      delegation_members
+        .map((m) => m.team_name_snapshot)
+        .filter((t): t is string => !!t && t.trim() !== ""),
+    ),
+  ];
+
+  return {
+    ...mapRow(row),
+    notes: row.notes,
+    location: row.location,
+    links: row.links ?? [],
+    delegation_members,
+    represented_teams,
+  };
 }

--- a/lib/meetings/queries.ts
+++ b/lib/meetings/queries.ts
@@ -219,7 +219,11 @@ type RawDetailDelegationMember = {
   role: string;
   team_id: string | null;
   team_name_snapshot: string | null;
-  profiles: { first_name: string | null; last_name: string | null } | null;
+  profiles: {
+    first_name: string | null;
+    last_name: string | null;
+    email: string;
+  } | null;
 };
 
 type RawDetailRow = Omit<RawRow, "meeting_delegation_members"> & {
@@ -245,7 +249,7 @@ const SELECT_DETAIL = `
   representatives!inner ( bioguide_id, official_full_name, state, district, party ),
   staffers ( first_name, last_name ),
   teams ( name, slug ),
-  meeting_delegation_members ( id, user_id, role, team_id, team_name_snapshot, profiles ( first_name, last_name ) )
+  meeting_delegation_members ( id, user_id, role, team_id, team_name_snapshot, profiles ( first_name, last_name, email ) )
 `;
 
 export async function fetchMeetingDetail(
@@ -270,6 +274,7 @@ export async function fetchMeetingDetail(
             .filter(Boolean)
             .join(" ") || "Anonymous"
         : "Anonymous",
+      email: m.profiles?.email ?? null,
       role: m.role as DelegationRole,
       team_id: m.team_id,
       team_name_snapshot: m.team_name_snapshot,

--- a/lib/meetings/types.ts
+++ b/lib/meetings/types.ts
@@ -35,6 +35,8 @@ export type MeetingLink = {
 export type DelegationMember = {
   id: string;
   user_id: string;
+  first_name: string;
+  last_name: string;
   display_name: string;
   email: string | null;
   role: DelegationRole;

--- a/lib/meetings/types.ts
+++ b/lib/meetings/types.ts
@@ -36,6 +36,7 @@ export type DelegationMember = {
   id: string;
   user_id: string;
   display_name: string;
+  email: string | null;
   role: DelegationRole;
   team_id: string | null;
   team_name_snapshot: string | null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@axe-core/playwright": "^4.11.1",
         "@eslint/eslintrc": "^3",
         "@playwright/test": "^1.60.0",
+        "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/typography": "^0.5.19",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -3631,6 +3632,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
       }
     },
     "node_modules/@tailwindcss/typography": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@axe-core/playwright": "^4.11.1",
     "@eslint/eslintrc": "^3",
     "@playwright/test": "^1.60.0",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 import typography from "@tailwindcss/typography";
 import tailwindcssAnimate from "tailwindcss-animate";
+import containerQueries from "@tailwindcss/container-queries";
 
 export default {
   darkMode: ["class"],
@@ -64,5 +65,5 @@ export default {
       },
     },
   },
-  plugins: [tailwindcssAnimate, typography],
+  plugins: [tailwindcssAnimate, typography, containerQueries],
 } satisfies Config;

--- a/tests/meetings.spec.ts
+++ b/tests/meetings.spec.ts
@@ -183,3 +183,24 @@ test.describe("create meeting", () => {
     ).toBeVisible();
   });
 });
+
+test.describe("expand meeting", () => {
+  test("expand row shows read-only detail panel (not edit form)", async ({
+    page,
+  }) => {
+    await page.goto("/meetings");
+
+    const expandBtn = page
+      .getByRole("button", { name: /Expand meeting with/ })
+      .first();
+    await expandBtn.click();
+    await expect(expandBtn).toHaveAttribute("aria-expanded", "true");
+
+    await expect(
+      page.getByRole("button", { name: /Edit Meeting/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Save changes" }),
+    ).not.toBeVisible();
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,12 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { beforeAll, afterEach, afterAll } from "vitest";
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
 import { server } from "./__tests__/mocks/supabase";
 
 // Point the Supabase client at localhost so MSW can intercept


### PR DESCRIPTION
## Summary

- Clicking a meeting row expands it inline to show full details: location, notes, links, delegation members, and champion score
- New `MeetingDetailView` component renders the detail panel in a responsive two-column layout (via `@tailwindcss/container-queries`)
- New slim `MeetingDetail` loader fetches the detail data and renders the view panel; the Edit button is present but a no-op at this stage
- `aria-controls` wired on the expand toggle button for accessibility
