### PR TITLE
Run Vitest before Supabase start

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -21,10 +21,10 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: npm ci
-      - name: Start Supabase
-        run: npx supabase start
       - name: Run Vitest tests
         run: npx vitest run
+      - name: Start Supabase
+        run: npx supabase start
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
       - name: Run E2E Playwright tests


### PR DESCRIPTION
## Summary

- Moves the Vitest step before `supabase start` in the E2E job
- All Vitest tests mock the Supabase client and don't need a running instance
- Fails fast on unit test failures without waiting for Supabase to boot

## Test plan

- [ ] Confirm CI passes with the new step order