### PR TITLE
Add rep profile schema migrations

### DIFF
--- a/supabase/migrations/20260520000000_add_rep_pronouns_email.sql
+++ b/supabase/migrations/20260520000000_add_rep_pronouns_email.sql
@@ -1,0 +1,3 @@
+alter table public.representatives
+  add column pronouns text,
+  add column email text;

--- a/supabase/migrations/20260520000001_add_staffer_contact_fields.sql
+++ b/supabase/migrations/20260520000001_add_staffer_contact_fields.sql
@@ -1,0 +1,3 @@
+alter table public.staffers
+  add column phone text,
+  add column location text;

--- a/supabase/migrations/20260520000002_add_teams_districts_index.sql
+++ b/supabase/migrations/20260520000002_add_teams_districts_index.sql
@@ -1,0 +1,2 @@
+create index idx_teams_congressional_districts
+  on public.teams using gin (congressional_districts);


### PR DESCRIPTION
## What

Extracts the three schema migrations from the `rep-profile` feature branch into a standalone PR so the schema lands in `main` **before** the code that depends on it.

| Migration | Change |
|-----------|--------|
| `20260520000000_add_rep_pronouns_email` | `representatives`: add `pronouns`, `email` |
| `20260520000001_add_staffer_contact_fields` | `staffers`: add `phone`, `location` |
| `20260520000002_add_teams_districts_index` | `teams`: add GIN index on `congressional_districts` |

## Why

- **Migrations before code.** The rep-profile feature code reads these columns; merging the schema first keeps `main` in a state where the code is never ahead of the database.
- **Enables Vercel PR previews.** Preview deploys for the rep-profile PR need these columns/index to exist.

## Notes

- All three are additive (new columns / new index) on tables that already exist in `main` (`representatives`, `staffers`, `teams.congressional_districts`), so they apply cleanly and independently.
- No application code in this PR — schema only.
- After this merges, the `rep-profile` branch already contains identical copies of these files, so they'll de-duplicate on the follow-up merge with no conflict.