### PR TITLE
Switch design palette to new brand hex codes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,26 +7,35 @@
     font-family: "Calibri", "Trebuchet MS", sans-serif;
   }
 
+  /*
+   * Brand palette (use these hex codes in all future color work):
+   *   Text against white:    #282828 → 0 0% 15.7%
+   *   Text against a header: #111111 → 0 0% 6.7%
+   *   Pronoun text:          #555555 → 0 0% 33.3%
+   *   Orange:                #F4A42E → 35.8 90% 56.9%
+   *   Pink:                  #E77EA3 → 338.9 68.6% 70%
+   *   Turquoise:             #5AB7C4 → 187.4 47.3% 56.1%
+   */
   :root {
     --background: 0 0% 100%;
-    --foreground: 0 0% 16%;
+    --foreground: 0 0% 15.7%; /* #282828 */
     --card: 25 100% 95%;
-    --card-foreground: 0 0% 16%;
+    --card-foreground: 0 0% 15.7%;
     --popover: 25 100% 95%;
-    --popover-foreground: 0 0% 16%;
+    --popover-foreground: 0 0% 15.7%;
     --popover-accent: 0 0% 100%;
-    --primary: 36 100% 50%;
-    --primary-foreground: 0 0% 0%;
-    --primary-dark: 36 100% 33%;
-    --primary-light: 36 100% 62%;
-    --primary-lighter: 36 100% 70%;
-    --nav-active: 36 90% 57%;
-    --nav-active-foreground: 0 0% 0%;
+    --primary: 35.8 90% 56.9%; /* #F4A42E */
+    --primary-foreground: 0 0% 6.7%; /* #111111 */
+    --primary-dark: 35.8 90% 33%;
+    --primary-light: 35.8 90% 65%;
+    --primary-lighter: 35.8 90% 72%;
+    --nav-active: 35.8 90% 56.9%;
+    --nav-active-foreground: 0 0% 6.7%;
     --secondary: 0 0% 94.1%;
     --secondary-foreground: 0 0% 9%;
     --secondary-dark: 0 0% 85%;
     --muted: 25 100% 95%;
-    --muted-foreground: 0 0% 25%;
+    --muted-foreground: 0 0% 33.3%; /* #555555 — pronoun/muted text */
     --accent: 25 100% 95%;
     --accent-foreground: 0 0% 9%;
     --accent-hover: 25 100% 88%;
@@ -41,12 +50,12 @@
     --ring: 0 0% 3.9%;
     --radius: 0.5rem;
     --bg-muted: 0 0% 100%;
-    --secondary-teal: 178.52 51.26% 46.67%;
-    --secondary-teal-foreground: 0 0% 0%;
-    --secondary-teal-accent: 182 51% 42%;
-    --secondary-magenta: 341 57% 58%;
-    --secondary-magenta-foreground: 0 0% 0%;
-    --secondary-magenta-accent: 341 57% 68%;
+    --secondary-teal: 187.4 47.3% 56.1%; /* #5AB7C4 */
+    --secondary-teal-foreground: 0 0% 6.7%;
+    --secondary-teal-accent: 187.4 47.3% 51.4%;
+    --secondary-magenta: 338.9 68.6% 70%; /* #E77EA3 */
+    --secondary-magenta-foreground: 0 0% 6.7%;
+    --secondary-magenta-accent: 338.9 68.6% 80%;
     --secondary-purple: 239 39% 32%;
     --secondary-purple-foreground: 0 0% 100%;
     --secondary-purple-accent: 239 39% 42%;
@@ -113,13 +122,13 @@
     --popover: 0 0% 3.9%;
     --popover-foreground: 0 0% 98%;
     --popover-accent: 0 0% 16%;
-    --primary: 33 100% 50%;
-    --primary-foreground: 0 0% 9%;
-    --primary-dark: 33 100% 43%;
-    --primary-light: 33 96.6% 58%;
-    --primary-lighter: 33 92.6% 66%;
-    --nav-active: 36 90% 57%;
-    --nav-active-foreground: 0 0% 0%;
+    --primary: 35.8 90% 56.9%; /* #F4A42E */
+    --primary-foreground: 0 0% 6.7%; /* #111111 */
+    --primary-dark: 35.8 90% 43%;
+    --primary-light: 35.8 90% 65%;
+    --primary-lighter: 35.8 90% 72%;
+    --nav-active: 35.8 90% 56.9%;
+    --nav-active-foreground: 0 0% 6.7%;
     --secondary: 0 0% 22%;
     --secondary-foreground: 0 0% 98%;
     --secondary-dark: 0 0% 28%;
@@ -137,12 +146,12 @@
     --border: 0 0% 28%;
     --input: 0 0% 28%;
     --ring: 0 0% 83.1%;
-    --secondary-teal: 182 51% 32%;
+    --secondary-teal: 187.4 47.3% 32%;
     --secondary-teal-foreground: 0 0% 100%;
-    --secondary-teal-accent: 182 51% 42%;
-    --secondary-magenta: 341 57% 50%;
+    --secondary-teal-accent: 187.4 47.3% 42%;
+    --secondary-magenta: 338.9 68.6% 50%;
     --secondary-magenta-foreground: 0 0% 100%;
-    --secondary-magenta-accent: 341 57% 60%;
+    --secondary-magenta-accent: 338.9 68.6% 60%;
     --secondary-purple: 239 39% 40%;
     --secondary-purple-foreground: 0 0% 100%;
     --secondary-purple-accent: 239 39% 50%;

--- a/tests/auth-a11y.spec.ts
+++ b/tests/auth-a11y.spec.ts
@@ -28,7 +28,7 @@ for (const { name, path } of authPages) {
       }, theme);
 
       const results = await new AxeBuilder({ page })
-        .exclude("h1") // primary color (#ff8c00) on white fails contrast — known issue, tracked separately
+        .exclude("h1") // primary color (#F4A42E) on white fails contrast — known issue, tracked separately
         .analyze();
 
       expect(results.violations).toEqual([]);


### PR DESCRIPTION
## Summary
Updates the design system in `app/globals.css` to the new canonical brand palette:

| Role | Hex | Token(s) |
|---|---|---|
| Text against white | `#282828` | `--foreground`, `--card-foreground`, `--popover-foreground` |
| Text against a header | `#111111` | `--primary-foreground`, `--nav-active-foreground`, `--secondary-teal-foreground`, `--secondary-magenta-foreground` |
| Pronoun / muted text | `#555555` | `--muted-foreground` |
| Orange | `#F4A42E` | `--primary`, `--nav-active` |
| Pink | `#E77EA3` | `--secondary-magenta` |
| Turquoise | `#5AB7C4` | `--secondary-teal` |

Derived shades (`--primary-dark/light/lighter`, `*-accent`) and the dark theme are retuned to the new hues, keeping dark-appropriate lightness so text contrast holds. The high-contrast theme is monochrome by design and is untouched. The palette is documented in a comment block in `globals.css` so future color work follows it.

Also updates a stale hex in an a11y test comment (the `h1` axe exclusion — orange on white remains a known, separately tracked contrast issue).