### PR TITLE
Add recovery email template and wire up SES auth email config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ node_modules/
 /specs/
 .claude/
 .specify/
+/openspec/

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -10,7 +10,12 @@ export async function GET(request: NextRequest) {
   const rawNext = searchParams.get("next") ?? "/";
   // Only allow relative paths to prevent open redirect.
   const next =
-    rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "/";
+    rawNext.startsWith("/") &&
+    !rawNext.startsWith("//") &&
+    !rawNext.includes("\\") &&
+    !/[\r\n]/.test(rawNext)
+      ? rawNext
+      : "/";
 
   if (token_hash && type) {
     const supabase = await createClient();

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -7,7 +7,10 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const token_hash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
-  const next = searchParams.get("next") ?? "/";
+  const rawNext = searchParams.get("next") ?? "/";
+  // Only allow relative paths to prevent open redirect.
+  const next =
+    rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "/";
 
   if (token_hash && type) {
     const supabase = await createClient();

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -216,15 +216,16 @@ otp_length = 6
 # Number of seconds before the email OTP expires (defaults to 1 hour).
 otp_expiry = 3600
 
-# Use a production-ready SMTP server
+# SMTP is configured in the hosted Supabase dashboard (Authentication → SMTP Settings),
+# not here. Local dev uses the Inbucket catcher at port 54324.
 # [auth.email.smtp]
 # enabled = true
-# host = "smtp.sendgrid.net"
+# host = "email-smtp.us-east-1.amazonaws.com"
 # port = 587
-# user = "apikey"
-# pass = "env(SENDGRID_API_KEY)"
-# admin_email = "admin@email.com"
-# sender_name = "Admin"
+# user = "env(SES_SMTP_USER)"
+# pass = "env(SES_SMTP_PASSWORD)"
+# admin_email = "no-reply@pihengage.org"
+# sender_name = "PIH Engage"
 
 # Uncomment to customize email template
 # [auth.email.template.invite]

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -176,7 +176,7 @@ password_requirements = ""
 
 [auth.rate_limit]
 # Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
-email_sent = 2
+email_sent = 200
 # Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
 sms_sent = 30
 # Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
@@ -238,6 +238,10 @@ otp_expiry = 3600
 [auth.email.template.confirmation]
 subject = "PIH Engage: Confirm your email for the advocacy dashboard"
 content_path = "./supabase/templates/confirmation.html"
+
+[auth.email.template.recovery]
+subject = "PIH Engage: Reset your password"
+content_path = "./supabase/templates/recovery.html"
 
 # Uncomment to customize notification email template
 # [auth.email.notification.password_changed]

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,33 @@
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#ffffff;margin:0;padding:32px 16px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <tr>
+    <td align="center">
+      <table role="presentation" width="480" cellpadding="0" cellspacing="0" border="0" style="width:480px;max-width:100%;">
+        <tr>
+          <td align="center" style="padding-bottom:28px;">
+            <img src="{{ .SiteURL }}/engage-logo.png" alt="Partners In Health Engage" width="220" style="display:block;width:220px;max-width:70%;height:auto;border:0;outline:none;text-decoration:none;" />
+          </td>
+        </tr>
+        <tr>
+          <td style="background-color:#fff1e6;border-radius:16px;padding:36px 32px;">
+            <h1 style="margin:0 0 6px;font-size:28px;line-height:1.2;font-weight:700;color:#282828;">Reset your password</h1>
+            <p style="margin:0 0 22px;font-size:15px;line-height:1.4;color:#555555;">We received a request to reset your password.</p>
+            <p style="margin:0 0 14px;font-size:16px;line-height:1.6;font-weight:700;color:#282828;">Hello{{ if .Data.first_name }}, {{ .Data.first_name }}{{ end }}!</p>
+            <p style="margin:0 0 28px;font-size:16px;line-height:1.6;color:#282828;">Click the button below to choose a new password for your PIH Engage account. This link expires in 1 hour.</p>
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+              <tr>
+                <td align="center" bgcolor="#f4a42e" style="border-radius:8px;">
+                  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery&next=/auth/update-password" style="display:block;padding:15px 24px;font-size:16px;font-weight:700;color:#111111;text-decoration:none;border-radius:8px;">Reset your password</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:22px 8px 0;">
+            <p style="margin:0;font-size:13px;line-height:1.5;color:#8a8a8a;">If you didn't request a password reset, you can safely ignore this email. Your password will not change.</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
- Add supabase/templates/recovery.html (branded password reset email routing through /auth/confirm?type=recovery)
- Register [auth.email.template.recovery] in config.toml
- Raise auth email rate limit from 2 to 200/hr
- Ignore /openspec/ in .gitignore

SES SMTP is configured in the hosted Supabase dashboard only; local dev continues using Inbucket. Pending: SES domain verification and dashboard wiring (tasks 5.x).