### PR TITLE
Fixing WebKit - Add router navigation for team rows in TeamsTableClient

### DIFF
--- a/components/teams/teams-table-client.tsx
+++ b/components/teams/teams-table-client.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { TYPE_BADGE_CLASS } from "@/lib/teams";
@@ -25,6 +26,7 @@ export type TeamTableRow = {
 };
 
 export function TeamsTableClient({ teams }: { teams: TeamTableRow[] }) {
+  const router = useRouter();
   const [search, setSearch] = useState("");
 
   const filtered = useMemo(() => {
@@ -64,11 +66,15 @@ export function TeamsTableClient({ teams }: { teams: TeamTableRow[] }) {
               </TableRow>
             ) : (
               filtered.map((team) => (
-                <TableRow key={team.slug} className="relative">
+                <TableRow
+                  key={team.slug}
+                  className="cursor-pointer"
+                  onClick={() => router.push(`/teams/${team.slug}`)}
+                >
                   <TableCell className="font-medium">
                     <Link
                       href={`/teams/${team.slug}`}
-                      className="after:absolute after:inset-0"
+                      onClick={(e) => e.stopPropagation()}
                     >
                       {team.name}
                     </Link>

--- a/components/teams/teams-table-client.tsx
+++ b/components/teams/teams-table-client.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { TYPE_BADGE_CLASS } from "@/lib/teams";
@@ -25,8 +24,20 @@ export type TeamTableRow = {
   members: number;
 };
 
+// An invisible, non-focusable link that fills its (relatively positioned) cell
+// so the whole row is clickable with a real anchor. Anchoring to the cell — not
+// the row — is deliberate: Safari/WebKit doesn't treat a `<tr>` as a containing
+// block for absolutely positioned children, so `inset-0` on a `<tr>` escapes the
+// row. Cells position correctly across browsers. `aria-hidden` + `tabIndex={-1}`
+// keep it out of the accessibility tree and tab order, so screen readers and
+// keyboard users see exactly one link per row (the team name in the first cell).
+function RowLinkOverlay({ href }: { href: string }) {
+  return (
+    <Link href={href} aria-hidden tabIndex={-1} className="absolute inset-0" />
+  );
+}
+
 export function TeamsTableClient({ teams }: { teams: TeamTableRow[] }) {
-  const router = useRouter();
   const [search, setSearch] = useState("");
 
   const filtered = useMemo(() => {
@@ -65,33 +76,42 @@ export function TeamsTableClient({ teams }: { teams: TeamTableRow[] }) {
                 </TableCell>
               </TableRow>
             ) : (
-              filtered.map((team) => (
-                <TableRow
-                  key={team.slug}
-                  className="cursor-pointer"
-                  onClick={() => router.push(`/teams/${team.slug}`)}
-                >
-                  <TableCell className="font-medium">
-                    <Link
-                      href={`/teams/${team.slug}`}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {team.name}
-                    </Link>
-                  </TableCell>
-                  <TableCell>
-                    <Badge
-                      variant="outline"
-                      className={TYPE_BADGE_CLASS[team.type] ?? ""}
-                    >
-                      {team.typeLabel}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>{team.state}</TableCell>
-                  <TableCell>{team.leads}</TableCell>
-                  <TableCell>{team.members}</TableCell>
-                </TableRow>
-              ))
+              filtered.map((team) => {
+                const href = `/teams/${team.slug}`;
+                return (
+                  <TableRow key={team.slug}>
+                    <TableCell className="relative font-medium">
+                      <Link
+                        href={href}
+                        className="after:absolute after:inset-0"
+                      >
+                        {team.name}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="relative">
+                      <Badge
+                        variant="outline"
+                        className={TYPE_BADGE_CLASS[team.type] ?? ""}
+                      >
+                        {team.typeLabel}
+                      </Badge>
+                      <RowLinkOverlay href={href} />
+                    </TableCell>
+                    <TableCell className="relative">
+                      {team.state}
+                      <RowLinkOverlay href={href} />
+                    </TableCell>
+                    <TableCell className="relative">
+                      {team.leads}
+                      <RowLinkOverlay href={href} />
+                    </TableCell>
+                    <TableCell className="relative">
+                      {team.members}
+                      <RowLinkOverlay href={href} />
+                    </TableCell>
+                  </TableRow>
+                );
+              })
             )}
           </TableBody>
         </Table>


### PR DESCRIPTION
Bug fix for iPhones on iOS version <=26 due to an [underlying WebKit issue](https://bugs.webkit.org/show_bug.cgi?id=240961). 

It has been resolved in the iOS 27 beta but this element should still be changed as I do not think everyone will update immediately (and it's not even out on stable).