### PR TITLE
Add an admin page

### DIFF
--- a/__tests__/components/admin/users-table-client.test.tsx
+++ b/__tests__/components/admin/users-table-client.test.tsx
@@ -1,0 +1,289 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  UsersTableClient,
+  type AdminUserRow,
+} from "@/components/admin/users-table-client";
+
+const ALL_TEAMS = [
+  { name: "Alpha Team", slug: "alpha-team" },
+  { name: "Beta Squad", slug: "beta-squad" },
+];
+
+function makeUser(overrides: Partial<AdminUserRow> = {}): AdminUserRow {
+  return {
+    user_id: "user-1",
+    fullName: "Jane Doe",
+    email: "jane@example.com",
+    isAdmin: false,
+    teams: [],
+    ...overrides,
+  };
+}
+
+function makeUsers(count: number): AdminUserRow[] {
+  return Array.from({ length: count }, (_, index) => ({
+    user_id: `user-${index + 1}`,
+    fullName: `User ${String(index + 1).padStart(3, "0")}`,
+    email: `user${index + 1}@example.com`,
+    isAdmin: false,
+    teams: [],
+  }));
+}
+
+describe("UsersTableClient — rendering", () => {
+  it("renders user names and emails", () => {
+    render(
+      <UsersTableClient
+        users={[
+          makeUser(),
+          makeUser({
+            user_id: "user-2",
+            fullName: "Bob Smith",
+            email: "bob@example.com",
+          }),
+        ]}
+        allTeams={[]}
+      />,
+    );
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("jane@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Bob Smith")).toBeInTheDocument();
+    expect(screen.getByText("bob@example.com")).toBeInTheDocument();
+  });
+
+  it("shows the admin shield icon for admin users but not for regular users", () => {
+    render(
+      <UsersTableClient
+        users={[
+          makeUser({ user_id: "u1", fullName: "Admin User", isAdmin: true }),
+          makeUser({ user_id: "u2", fullName: "Regular User", isAdmin: false }),
+        ]}
+        allTeams={[]}
+      />,
+    );
+    const adminCell = screen.getByText("Admin User").closest("td");
+    const regularCell = screen.getByText("Regular User").closest("td");
+    expect(adminCell?.querySelector("svg")).toBeInTheDocument();
+    expect(regularCell?.querySelector("svg")).not.toBeInTheDocument();
+  });
+
+  it("renders team links for users with teams", () => {
+    render(
+      <UsersTableClient
+        users={[
+          makeUser({ teams: [{ name: "Alpha Team", slug: "alpha-team" }] }),
+        ]}
+        allTeams={ALL_TEAMS}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Alpha Team" });
+    expect(link).toHaveAttribute("href", "/teams/alpha-team");
+  });
+
+  it("renders multiple team links when a user is on several teams", () => {
+    render(
+      <UsersTableClient
+        users={[
+          makeUser({
+            teams: [
+              { name: "Alpha Team", slug: "alpha-team" },
+              { name: "Beta Squad", slug: "beta-squad" },
+            ],
+          }),
+        ]}
+        allTeams={ALL_TEAMS}
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: "Alpha Team" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Beta Squad" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an em-dash for users with no teams", () => {
+    render(<UsersTableClient users={[makeUser()]} allTeams={[]} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("shows the empty state row when no users match the current filter", async () => {
+    render(<UsersTableClient users={[makeUser()]} allTeams={[]} />);
+    await userEvent.type(screen.getByRole("searchbox"), "zzznomatch");
+    expect(
+      screen.getByText("No users match your filters."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("UsersTableClient — count text", () => {
+  it('shows "0 users" when no users match the filter', async () => {
+    render(<UsersTableClient users={[makeUser()]} allTeams={[]} />);
+    await userEvent.type(screen.getByRole("searchbox"), "zzznomatch");
+    expect(screen.getByText("0 users")).toBeInTheDocument();
+  });
+
+  it('shows singular "1 user" for exactly one result', () => {
+    render(<UsersTableClient users={[makeUser()]} allTeams={[]} />);
+    expect(screen.getByText("1–1 of 1 user")).toBeInTheDocument();
+  });
+
+  it('shows plural "N users" for multiple results', () => {
+    render(
+      <UsersTableClient
+        users={[
+          makeUser({ user_id: "u1", fullName: "Alice" }),
+          makeUser({ user_id: "u2", fullName: "Bob" }),
+        ]}
+        allTeams={[]}
+      />,
+    );
+    expect(screen.getByText("1–2 of 2 users")).toBeInTheDocument();
+  });
+});
+
+describe("UsersTableClient — name search", () => {
+  const users = [
+    makeUser({
+      user_id: "u1",
+      fullName: "Alice Adams",
+      email: "alice@example.com",
+    }),
+    makeUser({
+      user_id: "u2",
+      fullName: "Bob Brown",
+      email: "bob@example.com",
+    }),
+  ];
+
+  it("filters users by name substring (case-insensitive)", async () => {
+    render(<UsersTableClient users={users} allTeams={[]} />);
+    await userEvent.type(screen.getByRole("searchbox"), "alice");
+    expect(screen.getByText("Alice Adams")).toBeInTheDocument();
+    expect(screen.queryByText("Bob Brown")).not.toBeInTheDocument();
+  });
+
+  it("shows all users when the search is cleared", async () => {
+    render(<UsersTableClient users={users} allTeams={[]} />);
+    await userEvent.type(screen.getByRole("searchbox"), "alice");
+    await userEvent.clear(screen.getByRole("searchbox"));
+    expect(screen.getByText("Alice Adams")).toBeInTheDocument();
+    expect(screen.getByText("Bob Brown")).toBeInTheDocument();
+  });
+});
+
+describe("UsersTableClient — team filter", () => {
+  const users = [
+    makeUser({
+      user_id: "u1",
+      fullName: "Alice Adams",
+      teams: [{ name: "Alpha Team", slug: "alpha-team" }],
+    }),
+    makeUser({
+      user_id: "u2",
+      fullName: "Bob Brown",
+      teams: [{ name: "Beta Squad", slug: "beta-squad" }],
+    }),
+    makeUser({ user_id: "u3", fullName: "Carol Chen", teams: [] }),
+  ];
+
+  it("filters to users on a specific team", async () => {
+    render(<UsersTableClient users={users} allTeams={ALL_TEAMS} />);
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(screen.getByRole("option", { name: "Alpha Team" }));
+    expect(screen.getByText("Alice Adams")).toBeInTheDocument();
+    expect(screen.queryByText("Bob Brown")).not.toBeInTheDocument();
+    expect(screen.queryByText("Carol Chen")).not.toBeInTheDocument();
+  });
+
+  it('filters to users with no team when "No team" is selected', async () => {
+    render(<UsersTableClient users={users} allTeams={ALL_TEAMS} />);
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(screen.getByRole("option", { name: "No team" }));
+    expect(screen.queryByText("Alice Adams")).not.toBeInTheDocument();
+    expect(screen.queryByText("Bob Brown")).not.toBeInTheDocument();
+    expect(screen.getByText("Carol Chen")).toBeInTheDocument();
+  });
+
+  it('shows all users when the filter is cleared to "All teams"', async () => {
+    render(<UsersTableClient users={users} allTeams={ALL_TEAMS} />);
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(screen.getByRole("option", { name: "Alpha Team" }));
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(screen.getByRole("option", { name: "All teams" }));
+    expect(screen.getByText("Alice Adams")).toBeInTheDocument();
+    expect(screen.getByText("Bob Brown")).toBeInTheDocument();
+    expect(screen.getByText("Carol Chen")).toBeInTheDocument();
+  });
+});
+
+describe("UsersTableClient — pagination", () => {
+  it("does not show pagination controls for 25 or fewer users", () => {
+    render(<UsersTableClient users={makeUsers(25)} allTeams={[]} />);
+    expect(
+      screen.queryByRole("button", { name: "Next" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Previous" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows pagination controls when there are more than 25 users", () => {
+    render(<UsersTableClient users={makeUsers(26)} allTeams={[]} />);
+    expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Previous" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the first-page range and disables Previous on page 1", () => {
+    render(<UsersTableClient users={makeUsers(26)} allTeams={[]} />);
+    expect(screen.getByText("1–25 of 26 users")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next" })).not.toBeDisabled();
+  });
+
+  it("advances to page 2 and disables Next on the last page", async () => {
+    render(<UsersTableClient users={makeUsers(26)} allTeams={[]} />);
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("26–26 of 26 users")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Previous" })).not.toBeDisabled();
+  });
+
+  it("returns to page 1 when Previous is clicked from page 2", async () => {
+    render(<UsersTableClient users={makeUsers(26)} allTeams={[]} />);
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    await userEvent.click(screen.getByRole("button", { name: "Previous" }));
+    expect(screen.getByText("1–25 of 26 users")).toBeInTheDocument();
+  });
+
+  it("resets to page 1 when the name search changes", async () => {
+    render(<UsersTableClient users={makeUsers(26)} allTeams={[]} />);
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("26–26 of 26 users")).toBeInTheDocument();
+    await userEvent.type(screen.getByRole("searchbox"), "001");
+    expect(screen.getByText("1–1 of 1 user")).toBeInTheDocument();
+  });
+
+  it("resets to page 1 when the team filter changes", async () => {
+    const users = [
+      ...makeUsers(25),
+      makeUser({
+        user_id: "user-26",
+        fullName: "Zara Zoom",
+        email: "zara@example.com",
+        teams: [{ name: "Alpha Team", slug: "alpha-team" }],
+      }),
+    ];
+    render(<UsersTableClient users={users} allTeams={ALL_TEAMS} />);
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Zara Zoom")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(screen.getByRole("option", { name: "Alpha Team" }));
+    expect(screen.getByText("1–1 of 1 user")).toBeInTheDocument();
+    expect(screen.getByText("Zara Zoom")).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/auth/guards.test.ts
+++ b/__tests__/lib/auth/guards.test.ts
@@ -74,6 +74,49 @@ describe("requireSuperAdmin", () => {
   });
 });
 
+describe("getIsAdmin", () => {
+  it("returns false when unauthenticated", async () => {
+    getCurrentRole.mockResolvedValue(null);
+    const { getIsAdmin } = await loadGuards();
+
+    await expect(getIsAdmin("pihe")).resolves.toBe(false);
+  });
+
+  it("returns false for a member", async () => {
+    getCurrentRole.mockResolvedValue(current({ role: "member" }));
+    const { getIsAdmin } = await loadGuards();
+
+    await expect(getIsAdmin("pihe")).resolves.toBe(false);
+  });
+
+  it("returns true for an org admin of the matching org", async () => {
+    getCurrentRole.mockResolvedValue(
+      current({ role: "org_admin", org_id: "pihe" }),
+    );
+    const { getIsAdmin } = await loadGuards();
+
+    await expect(getIsAdmin("pihe")).resolves.toBe(true);
+  });
+
+  it("returns false for an org admin of a different org", async () => {
+    getCurrentRole.mockResolvedValue(
+      current({ role: "org_admin", org_id: "other" }),
+    );
+    const { getIsAdmin } = await loadGuards();
+
+    await expect(getIsAdmin("pihe")).resolves.toBe(false);
+  });
+
+  it("returns true for a super admin regardless of org", async () => {
+    getCurrentRole.mockResolvedValue(
+      current({ role: "super_admin", org_id: null }),
+    );
+    const { getIsAdmin } = await loadGuards();
+
+    await expect(getIsAdmin("pihe")).resolves.toBe(true);
+  });
+});
+
 describe("requireOrgAdmin", () => {
   it("throws ForbiddenError for members", async () => {
     getCurrentRole.mockResolvedValue(current({ role: "member" }));

--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+import { requireOrgAdmin } from "@/lib/auth/guards";
+import { ORG_ID } from "@/lib/org";
+import { UsersList } from "@/components/admin/users-list";
+
+export const metadata: Metadata = { title: "Admin" };
+
+export default async function AdminPage() {
+  await requireOrgAdmin(ORG_ID);
+
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold">Admin</h1>
+      <h2 className="mt-6 text-xl font-semibold">User list</h2>
+      <Suspense fallback={<p className="text-muted-foreground">Loading…</p>}>
+        <UsersList />
+      </Suspense>
+    </div>
+  );
+}

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,11 +1,19 @@
 import { MobileHeader } from "@/components/mobile-header";
 import { Sidebar } from "@/components/sidebar";
+import { getIsAdmin } from "@/lib/auth/guards";
+import { ORG_ID } from "@/lib/org";
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+export default async function AppLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const isAdmin = await getIsAdmin(ORG_ID);
+
   return (
     <div className="flex h-svh flex-col md:flex-row">
-      <MobileHeader />
-      <Sidebar />
+      <MobileHeader isAdmin={isAdmin} />
+      <Sidebar isAdmin={isAdmin} />
       <main className="flex-1 overflow-y-auto">{children}</main>
     </div>
   );

--- a/components/admin/users-list.tsx
+++ b/components/admin/users-list.tsx
@@ -1,0 +1,81 @@
+import { createClient } from "@/lib/supabase/server";
+import { ORG_ID } from "@/lib/org";
+import {
+  UsersTableClient,
+  type AdminUserRow,
+} from "@/components/admin/users-table-client";
+
+export async function UsersList() {
+  const supabase = await createClient();
+
+  const [
+    { data: profiles, error },
+    { data: memberships },
+    { data: teams },
+    { data: roles },
+  ] = await Promise.all([
+    supabase
+      .from("profiles")
+      .select("user_id, first_name, last_name, email")
+      .eq("org_id", ORG_ID)
+      .order("last_name", { ascending: true })
+      .order("first_name", { ascending: true }),
+    supabase
+      .from("team_memberships")
+      .select("user_id, teams(name, slug)")
+      .eq("org_id", ORG_ID),
+    supabase
+      .from("teams")
+      .select("name, slug")
+      .eq("org_id", ORG_ID)
+      .order("name"),
+    supabase.from("user_role").select("user_id, role").eq("org_id", ORG_ID),
+  ]);
+
+  if (error)
+    return <p className="mt-6 text-destructive">Error: {error.message}</p>;
+  if (!profiles?.length)
+    return <p className="mt-6 text-muted-foreground">No users found.</p>;
+
+  const adminUserIds = new Set(
+    (roles ?? [])
+      .filter(
+        (role) => role.role === "org_admin" || role.role === "super_admin",
+      )
+      .map((role) => role.user_id),
+  );
+
+  const teamsByUser = new Map<string, { name: string; slug: string }[]>();
+  for (const membership of memberships ?? []) {
+    const raw = membership.teams as
+      | { name: string; slug: string }
+      | { name: string; slug: string }[]
+      | null;
+    if (!raw) continue;
+    const team = Array.isArray(raw) ? raw[0] : raw;
+    if (!team) continue;
+    const userTeams = teamsByUser.get(membership.user_id) ?? [];
+    userTeams.push({ name: team.name, slug: team.slug });
+    teamsByUser.set(membership.user_id, userTeams);
+  }
+
+  const userRows: AdminUserRow[] = profiles.map((profile) => ({
+    user_id: profile.user_id,
+    fullName:
+      [profile.first_name, profile.last_name].filter(Boolean).join(" ") ||
+      "(no name)",
+    email: profile.email,
+    isAdmin: adminUserIds.has(profile.user_id),
+    teams: teamsByUser.get(profile.user_id) ?? [],
+  }));
+
+  return (
+    <UsersTableClient
+      users={userRows}
+      allTeams={(teams ?? []).map((team) => ({
+        name: team.name,
+        slug: team.slug,
+      }))}
+    />
+  );
+}

--- a/components/admin/users-table-client.tsx
+++ b/components/admin/users-table-client.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ShieldUser } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FilterCombobox } from "@/components/ui/combobox";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export type AdminUserRow = {
+  user_id: string;
+  fullName: string;
+  email: string;
+  isAdmin: boolean;
+  teams: { name: string; slug: string }[];
+};
+
+const PAGE_SIZE = 25;
+const NO_TEAM_VALUE = "__no_team__";
+
+export function UsersTableClient({
+  users,
+  allTeams,
+}: {
+  users: AdminUserRow[];
+  allTeams: { name: string; slug: string }[];
+}) {
+  const [nameSearch, setNameSearch] = useState("");
+  const [teamFilter, setTeamFilter] = useState("");
+  const [page, setPage] = useState(1);
+
+  const filtered = useMemo(() => {
+    const query = nameSearch.trim().toLowerCase();
+    return users.filter((user) => {
+      if (query && !user.fullName.toLowerCase().includes(query)) return false;
+      if (teamFilter === NO_TEAM_VALUE) return user.teams.length === 0;
+      if (teamFilter !== "")
+        return user.teams.some((team) => team.slug === teamFilter);
+      return true;
+    });
+  }, [users, nameSearch, teamFilter]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [nameSearch, teamFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+  const start = filtered.length === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const end = Math.min(page * PAGE_SIZE, filtered.length);
+
+  return (
+    <div className="mt-2 space-y-4">
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="space-y-1">
+          <Label htmlFor="name-search">Name</Label>
+          <Input
+            id="name-search"
+            type="search"
+            placeholder="Search by name"
+            value={nameSearch}
+            onChange={(event) => setNameSearch(event.target.value)}
+            className="w-64"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="team-filter">Team</Label>
+          <div className="w-56">
+            <FilterCombobox
+              id="team-filter"
+              options={[
+                { id: NO_TEAM_VALUE, label: "No team" },
+                ...allTeams.map((team) => ({
+                  id: team.slug,
+                  label: team.name,
+                })),
+              ]}
+              value={teamFilter}
+              onChange={setTeamFilter}
+              clearLabel="All teams"
+              placeholder="All teams"
+            />
+          </div>
+        </div>
+      </div>
+
+      <Table>
+        <caption className="sr-only">Users</caption>
+        <TableHeader className="[&_th]:text-primary-foreground [&_tr]:bg-primary [&_tr]:hover:bg-primary">
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Teams</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {paginated.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={3} className="text-muted-foreground">
+                No users match your filters.
+              </TableCell>
+            </TableRow>
+          ) : (
+            paginated.map((user) => (
+              <TableRow key={user.user_id}>
+                <TableCell className="font-medium">
+                  <span className="flex items-center gap-1.5">
+                    {user.fullName}
+                    {user.isAdmin && (
+                      <ShieldUser
+                        size={14}
+                        className="shrink-0 text-muted-foreground"
+                      />
+                    )}
+                  </span>
+                </TableCell>
+                <TableCell>{user.email}</TableCell>
+                <TableCell>
+                  {user.teams.length === 0 ? (
+                    <span className="text-muted-foreground">—</span>
+                  ) : (
+                    <div className="flex flex-wrap gap-x-3 gap-y-1">
+                      {user.teams.map((team) => (
+                        <Link
+                          key={team.slug}
+                          href={`/teams/${team.slug}`}
+                          className="text-sm underline"
+                        >
+                          {team.name}
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {filtered.length === 0
+            ? "0 users"
+            : `${start}–${end} of ${filtered.length} user${filtered.length === 1 ? "" : "s"}`}
+        </p>
+        {totalPages > 1 && (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((currentPage) => currentPage - 1)}
+              disabled={page === 1}
+            >
+              Previous
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              Page {page} of {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((currentPage) => currentPage + 1)}
+              disabled={page === totalPages}
+            >
+              Next
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/users-table-client.tsx
+++ b/components/admin/users-table-client.tsx
@@ -116,10 +116,14 @@ export function UsersTableClient({
                   <span className="flex items-center gap-1.5">
                     {user.fullName}
                     {user.isAdmin && (
-                      <ShieldUser
-                        size={14}
-                        className="shrink-0 text-muted-foreground"
-                      />
+                      <>
+                        <ShieldUser
+                          size={14}
+                          aria-hidden="true"
+                          className="shrink-0 text-muted-foreground"
+                        />
+                        <span className="sr-only">(admin)</span>
+                      </>
                     )}
                   </span>
                 </TableCell>

--- a/components/mobile-header.tsx
+++ b/components/mobile-header.tsx
@@ -13,6 +13,7 @@ import {
   Menu,
   Moon,
   Palette,
+  ShieldUser,
   Sun,
   UserCircle,
   UsersRound,
@@ -34,7 +35,7 @@ const THEMES = [
   { value: "high-contrast", label: "High Contrast", icon: Contrast },
 ] as const;
 
-export function MobileHeader() {
+export function MobileHeader({ isAdmin = false }: { isAdmin?: boolean }) {
   const router = useRouter();
   const { setTheme } = useTheme();
   const [firstName, setFirstName] = React.useState<string | null>(null);
@@ -107,6 +108,14 @@ export function MobileHeader() {
             {firstName ? `${firstName}'s profile` : "Profile"}
           </Link>
         </DropdownMenuItem>
+        {isAdmin && (
+          <DropdownMenuItem asChild>
+            <Link href="/admin" className="flex items-center gap-2">
+              <ShieldUser size={16} />
+              Admin
+            </Link>
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={(e) => {

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   UserCircle,
   PanelLeftOpen,
   Landmark,
+  ShieldUser,
 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
@@ -51,7 +52,7 @@ function NavLink({
   );
 }
 
-export function Sidebar() {
+export function Sidebar({ isAdmin = false }: { isAdmin?: boolean }) {
   const router = useRouter();
 
   const [isCollapsed, setIsCollapsed] = React.useState(false);
@@ -147,6 +148,14 @@ export function Sidebar() {
           icon={UserCircle}
           isCollapsed={isCollapsed}
         />
+        {isAdmin && (
+          <NavLink
+            href="/admin"
+            label="Admin"
+            icon={ShieldUser}
+            isCollapsed={isCollapsed}
+          />
+        )}
       </nav>
       <div className="mt-auto flex flex-col">
         <div

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -34,10 +34,10 @@ const Option = memo(function Option({
       role="option"
       aria-selected={selected}
       onClick={onClick}
-      className={`flex w-full cursor-default select-none items-center gap-2 px-3 py-1.5 text-sm ${highlighted ? "text-popover-accent-foreground bg-popover-accent" : ""} hover:text-popover-accent-foreground hover:bg-popover-accent ${selected && !highlighted ? "bg-accent text-accent-foreground" : ""}`}
+      className={`flex w-full cursor-default select-none items-start gap-2 px-3 py-1.5 text-left text-sm ${highlighted ? "text-popover-accent-foreground bg-popover-accent" : ""} hover:text-popover-accent-foreground hover:bg-popover-accent ${selected && !highlighted ? "bg-accent text-accent-foreground" : ""}`}
     >
       <Check
-        className={`h-4 w-4 shrink-0 ${selected ? "opacity-100" : "opacity-0"}`}
+        className={`mt-px h-4 w-4 shrink-0 ${selected ? "opacity-100" : "opacity-0"}`}
       />
       <span className={muted ? "text-muted-foreground" : ""}>{label}</span>
     </button>
@@ -175,7 +175,7 @@ export function FilterCombobox({
           }}
           onFocus={() => setOpen(true)}
           onKeyDown={handleKeyDown}
-          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-2 pr-8 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-2 pr-8 text-left text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
         />
         <ChevronsUpDown className="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 shrink-0 -translate-y-1/2 opacity-50" />
       </div>

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -33,3 +33,10 @@ export async function requireOrgAdmin(orgId: string): Promise<CurrentRole> {
   }
   return current;
 }
+
+export async function getIsAdmin(orgId: string): Promise<boolean> {
+  const current = await getCurrentRole();
+  if (!current) return false;
+  if (current.role === "super_admin") return true;
+  return current.role === "org_admin" && current.org_id === orgId;
+}

--- a/supabase/migrations/20260622000000_allow_admins_read_org_roles.sql
+++ b/supabase/migrations/20260622000000_allow_admins_read_org_roles.sql
@@ -1,0 +1,9 @@
+-- Org admins need to read all user roles within their org (e.g. to display
+-- admin badges on the admin panel). Super admins can read all roles globally.
+-- The existing "users read own role" policy already covers the self-read case.
+create policy "org admins read own-org user roles"
+  on public.user_role for select to authenticated
+  using (
+    (org_id is not null and public.is_org_admin_for(org_id))
+    or public.is_super_admin()
+  );


### PR DESCRIPTION
https://github.com/lfryemason/pih-advocacy-engage/issues/134

Adds an admin page that allows admins (org or super) to search through users and see their name, email and team. This is mostly needed to see users that have no team.
<img width="1243" height="770" alt="image" src="https://github.com/user-attachments/assets/48e94a08-9208-4ec0-999c-587352227209" />
