### PR TITLE
Redirect to home after password update

### DIFF
--- a/components/update-password-form.tsx
+++ b/components/update-password-form.tsx
@@ -33,8 +33,7 @@ export function UpdatePasswordForm({
     try {
       const { error } = await supabase.auth.updateUser({ password });
       if (error) throw error;
-      // Update this route to redirect to an authenticated route. The user already has an active session.
-      router.push("/protected");
+      router.push("/");
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : "An error occurred");
     } finally {


### PR DESCRIPTION
## Summary
- Changes the post-password-update redirect from `/protected` to `/` to match the rest of the auth flow