### PR TITLE
Add checkboxes sitewise

### DIFF
--- a/__tests__/components/representatives/representatives-filters.test.tsx
+++ b/__tests__/components/representatives/representatives-filters.test.tsx
@@ -106,7 +106,7 @@ describe("RepresentativesFilters", () => {
 
     await user.click(screen.getByRole("button", { name: "Filter by state" }));
     await user.click(
-      await screen.findByRole("menuitem", { name: "Massachusetts" }),
+      await screen.findByRole("menuitemcheckbox", { name: "Massachusetts" }),
     );
 
     expect(onChange).toHaveBeenCalledWith({
@@ -127,7 +127,7 @@ describe("RepresentativesFilters", () => {
 
     await user.click(screen.getByRole("button", { name: "Filter by state" }));
     await user.click(
-      await screen.findByRole("menuitem", { name: "Massachusetts" }),
+      await screen.findByRole("menuitemcheckbox", { name: "Massachusetts" }),
     );
 
     expect(onChange).toHaveBeenCalledWith({ ...EMPTY_FILTERS, states: [] });
@@ -141,7 +141,9 @@ describe("RepresentativesFilters", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "Filter by party" }));
-    await user.click(await screen.findByRole("menuitem", { name: "Democrat" }));
+    await user.click(
+      await screen.findByRole("menuitemcheckbox", { name: "Democrat" }),
+    );
 
     expect(onChange).toHaveBeenCalledWith({
       ...EMPTY_FILTERS,

--- a/components/representatives/representatives-filters.tsx
+++ b/components/representatives/representatives-filters.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Check, ChevronDown, X } from "lucide-react";
+import { ChevronDown, X } from "lucide-react";
 import { debounce, xor } from "es-toolkit";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { US_STATES, StateCode } from "@/lib/us-districts";
@@ -89,24 +89,18 @@ export function RepresentativesFilters({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="max-h-64">
-          {US_STATES.map((state) => {
-            const checked = filters.states.includes(state.code);
-            return (
-              <DropdownMenuItem
-                key={state.code}
-                onSelect={(e) => {
-                  e.preventDefault();
-                  set({ states: xor(filters.states, [state.code]) });
-                }}
-                className="pr-2"
-              >
-                <span className="mr-2 flex h-4 w-4 items-center justify-center">
-                  {checked && <Check className="h-4 w-4" />}
-                </span>
-                {state.name}
-              </DropdownMenuItem>
-            );
-          })}
+          {US_STATES.map((state) => (
+            <DropdownMenuCheckboxItem
+              key={state.code}
+              checked={filters.states.includes(state.code)}
+              onSelect={(e) => {
+                e.preventDefault();
+                set({ states: xor(filters.states, [state.code]) });
+              }}
+            >
+              {state.name}
+            </DropdownMenuCheckboxItem>
+          ))}
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -123,24 +117,18 @@ export function RepresentativesFilters({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          {PARTIES.map((party) => {
-            const checked = filters.parties.includes(party);
-            return (
-              <DropdownMenuItem
-                key={party}
-                onSelect={(e) => {
-                  e.preventDefault();
-                  set({ parties: xor(filters.parties, [party]) });
-                }}
-                className="pr-2"
-              >
-                <span className="mr-2 flex h-4 w-4 items-center justify-center">
-                  {checked && <Check className="h-4 w-4" />}
-                </span>
-                {party}
-              </DropdownMenuItem>
-            );
-          })}
+          {PARTIES.map((party) => (
+            <DropdownMenuCheckboxItem
+              key={party}
+              checked={filters.parties.includes(party)}
+              onSelect={(e) => {
+                e.preventDefault();
+                set({ parties: xor(filters.parties, [party]) });
+              }}
+            >
+              {party}
+            </DropdownMenuCheckboxItem>
+          ))}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] origin-[--radix-dropdown-menu-content-transform-origin] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] origin-[--radix-dropdown-menu-content-transform-origin] overflow-hidden rounded-md border bg-background p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover py-1 text-popover-foreground shadow-md",
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-background py-1 text-popover-foreground shadow-md",
         "origin-[--radix-dropdown-menu-content-transform-origin] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
@@ -100,15 +100,15 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors hover:bg-popover-accent focus:bg-popover-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "group relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[state=checked]:bg-secondary data-[disabled]:opacity-50",
       className,
     )}
     checked={checked}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors group-data-[state=checked]:border-primary group-data-[state=checked]:bg-primary group-data-[state=checked]:text-primary-foreground">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="size-3.5" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}

--- a/tests/congress-table.spec.ts
+++ b/tests/congress-table.spec.ts
@@ -76,7 +76,7 @@ test.describe("congress table (e2e)", () => {
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Filter by party" }).click();
-    await page.getByRole("menuitem", { name: "Republican" }).click();
+    await page.getByRole("menuitemcheckbox", { name: "Republican" }).click();
     await page.keyboard.press("Escape");
 
     await expect(

--- a/tests/senators-table.spec.ts
+++ b/tests/senators-table.spec.ts
@@ -35,7 +35,7 @@ test.describe("senators table (e2e)", () => {
     await expect(table.getByRole("link", { name: "John Green" })).toBeVisible();
 
     await page.getByRole("button", { name: "Filter by state" }).click();
-    await page.getByRole("menuitem", { name: "Montana" }).click();
+    await page.getByRole("menuitemcheckbox", { name: "Montana" }).click();
     await page.keyboard.press("Escape");
 
     await expect(table.getByRole("link", { name: "Hank Green" })).toBeVisible();


### PR DESCRIPTION
This pull request updates the `RepresentativesFilters` component and related tests to use `DropdownMenuCheckboxItem` instead of `DropdownMenuItem` for state and party filters, improving accessibility and user experience. It also refines dropdown menu styling for better visual consistency.

**Component and UI improvements:**

* Replaced `DropdownMenuItem` with `DropdownMenuCheckboxItem` for state and party filters in `representatives-filters.tsx`, enabling checkbox-style multi-select and improving accessibility. [[1]](diffhunk://#diff-654800f18652eb8b8a5ee073ada7abdffbd85709a60617f17570bb2b12ba17f9L92-R103) [[2]](diffhunk://#diff-654800f18652eb8b8a5ee073ada7abdffbd85709a60617f17570bb2b12ba17f9L126-R131)
* Removed the unused `Check` icon import from `representatives-filters.tsx`.

**Dropdown menu styling updates:**

* Updated dropdown menu background classes from `bg-popover` to `bg-background` for both `DropdownMenuContent` and `DropdownMenuSubContent` to ensure consistent theming. [[1]](diffhunk://#diff-bc12d3573eefdb106075087f78e9340cc65ae99a33961f8400c48a3f4dee2611L50-R50) [[2]](diffhunk://#diff-bc12d3573eefdb106075087f78e9340cc65ae99a33961f8400c48a3f4dee2611L68-R68)
* Refined `DropdownMenuCheckboxItem` styling: improved focus, checked, and disabled states, and updated checkbox indicator visuals for clarity and accessibility.

**Testing updates:**

* Updated tests to use `menuitemcheckbox` role instead of `menuitem`, ensuring tests accurately reflect the new accessible checkbox menu items. [[1]](diffhunk://#diff-3109109e9fb1c81e94397aa4acf82c5a5b6196e28d720af3e48c50a8273043d6L109-R109) [[2]](diffhunk://#diff-3109109e9fb1c81e94397aa4acf82c5a5b6196e28d720af3e48c50a8273043d6L130-R130) [[3]](diffhunk://#diff-3109109e9fb1c81e94397aa4acf82c5a5b6196e28d720af3e48c50a8273043d6L144-R146)