### PR TITLE
Use skeleton loading state in PersonalMeetingsSection

### DIFF
--- a/components/meetings/personal-meetings-section.tsx
+++ b/components/meetings/personal-meetings-section.tsx
@@ -167,14 +167,6 @@ export function PersonalMeetingsSection(props: Props) {
     loadInitial(filtersRef.current);
   }, [loadInitial]);
 
-  if (loading) {
-    return (
-      <p role="status" className="py-8 text-center text-muted-foreground">
-        Loading…
-      </p>
-    );
-  }
-
   if (error) {
     return (
       <p role="alert" className="py-8 text-center text-destructive">
@@ -193,6 +185,7 @@ export function PersonalMeetingsSection(props: Props) {
         disableLoadMore={loadingMoreUpcoming}
         onRefresh={handleRefresh}
         variant={variant}
+        loading={loading}
       />
       <MeetingsSection
         title="Past Meetings"
@@ -203,6 +196,7 @@ export function PersonalMeetingsSection(props: Props) {
         onRefresh={handleRefresh}
         isPast
         variant={variant}
+        loading={loading}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Replaces the plain "Loading…" text in `PersonalMeetingsSection` with the table-skeleton pattern (`loading` prop on `MeetingsSection`), matching the behavior already used by the "All Meetings" section on the meetings page.
- My Meetings and Team Meetings now render consistently with the rest of the page while data is loading.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run __tests__/components/meetings` — 111/111 tests pass
- [ ] Manual check in browser: load /meetings and confirm My Meetings / Team Meetings show skeleton rows instead of "Loading…" text