### PR TITLE
Show pending tag for placeholder members on admin page

### DIFF
--- a/__tests__/components/admin/users-table-client.test.tsx
+++ b/__tests__/components/admin/users-table-client.test.tsx
@@ -17,6 +17,7 @@ function makeUser(overrides: Partial<AdminUserRow> = {}): AdminUserRow {
     fullName: "Jane Doe",
     email: "jane@example.com",
     isAdmin: false,
+    isPending: false,
     teams: [],
     ...overrides,
   };
@@ -28,6 +29,7 @@ function makeUsers(count: number): AdminUserRow[] {
     fullName: `User ${String(index + 1).padStart(3, "0")}`,
     email: `user${index + 1}@example.com`,
     isAdmin: false,
+    isPending: false,
     teams: [],
   }));
 }

--- a/components/admin/users-list.tsx
+++ b/components/admin/users-list.tsx
@@ -16,7 +16,7 @@ export async function UsersList() {
   ] = await Promise.all([
     supabase
       .from("profiles")
-      .select("user_id, first_name, last_name, email")
+      .select("user_id, first_name, last_name, email, is_placeholder")
       .eq("org_id", ORG_ID)
       .order("last_name", { ascending: true })
       .order("first_name", { ascending: true }),
@@ -66,6 +66,7 @@ export async function UsersList() {
       "(no name)",
     email: profile.email,
     isAdmin: adminUserIds.has(profile.user_id),
+    isPending: profile.is_placeholder,
     teams: teamsByUser.get(profile.user_id) ?? [],
   }));
 

--- a/components/admin/users-table-client.tsx
+++ b/components/admin/users-table-client.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { FilterCombobox } from "@/components/ui/combobox";
+import { PendingBadge } from "@/components/teams/pending-badge";
 import {
   Table,
   TableBody,
@@ -21,6 +22,7 @@ export type AdminUserRow = {
   fullName: string;
   email: string;
   isAdmin: boolean;
+  isPending: boolean;
   teams: { name: string; slug: string }[];
 };
 
@@ -125,6 +127,7 @@ export function UsersTableClient({
                         <span className="sr-only">(admin)</span>
                       </>
                     )}
+                    {user.isPending && <PendingBadge />}
                   </span>
                 </TableCell>
                 <TableCell>{user.email}</TableCell>


### PR DESCRIPTION
## Summary
- Admin page's user list now shows a "Pending" badge next to placeholder members (accounts that haven't signed up yet), matching the badge already used on the teams page.
- Reuses the existing `PendingBadge` component and `profiles.is_placeholder` field instead of adding a new indicator.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run __tests__/components/admin/users-table-client.test.tsx` passes (21 tests)