### PR TITLE
Fix unreadable select dropdown options in dark mode on Chromium/Windows

### DIFF
--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -18,7 +18,7 @@ const Select = React.forwardRef<
           onKeyDown?.(event);
         }}
         className={cn(
-          "flex h-9 w-full appearance-none rounded-md border border-input bg-background px-3 py-1 pr-8 text-base text-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full appearance-none rounded-md border border-input bg-background px-3 py-1 pr-8 text-base text-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-50 md:text-sm [&_option]:bg-background [&_option]:text-foreground",
           className,
         )}
         {...props}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -18,7 +18,7 @@ const Select = React.forwardRef<
           onKeyDown?.(event);
         }}
         className={cn(
-          "flex h-9 w-full appearance-none rounded-md border border-input bg-transparent px-3 py-1 pr-8 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full appearance-none rounded-md border border-input bg-background px-3 py-1 pr-8 text-base text-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-50 md:text-sm",
           className,
         )}
         {...props}

--- a/tests/regression/select-dropdown-regression.spec.ts
+++ b/tests/regression/select-dropdown-regression.spec.ts
@@ -8,20 +8,22 @@ test.beforeEach(resetDatabase);
 
 /*
  * Regression test for: native <select> popups rendering unreadable
- * (e.g. white-on-white) in Chrome on Windows when both the OS and the site
- * are in dark mode.
+ * (e.g. white-on-white) in Chrome on Windows when the site is in dark mode.
  *
- * Chromium keys the native option-list popup's colors off `color-scheme`,
- * but only if the <select> itself resolves to a real, non-transparent
- * background/text color — a `background-color: transparent` select gives
- * Chromium nothing to match the popup to, so it falls back to UA defaults
- * that can conflict with the inherited (theme) text color.
+ * Firefox and light mode are fine; only Chromium on Windows breaks. The reason
+ * is that Windows Chromium draws the option-list popup with a native OS menu
+ * that does NOT follow `color-scheme` for the option rows. With the select's
+ * text forced to the (light) foreground color and the options left with no
+ * explicit background, the popup rows fall back to the native light menu
+ * background — light text on a light row. The reliable fix across Chromium
+ * versions is to set an explicit background AND color on the <option>s
+ * themselves, which is what the shared <Select> now does.
  *
  * The popup itself is a native OS/browser widget, not part of the page's
  * render tree, so it can't be captured with page.screenshot() (confirmed:
- * clicking/opening a <select> never appears in a Playwright screenshot,
- * even headless on Linux). So instead we assert directly on the computed
- * style responsible for the bug.
+ * opening a <select> never appears in a Playwright screenshot, even headless
+ * on Linux). So instead we assert directly on the <option> computed style
+ * responsible for the bug.
  */
 for (const theme of themes) {
   test.describe(`select dropdown colors (${theme})`, () => {
@@ -31,23 +33,33 @@ for (const theme of themes) {
       await setTheme(page, theme);
     });
 
-    test("State and Congressional District selects have an opaque, theme-matched background", async ({
+    test("State and Congressional District options have an opaque, readable background", async ({
       page,
     }) => {
       for (const label of ["State", "Congressional District"]) {
         const select = page.getByLabel(label);
-        const { backgroundColor, color } = await select.evaluate((el) => {
-          const style = getComputedStyle(el);
-          return { backgroundColor: style.backgroundColor, color: style.color };
-        });
-
-        expect(backgroundColor, `${label} select background`).not.toBe(
-          "rgba(0, 0, 0, 0)",
+        const options = await select.evaluate((el) =>
+          Array.from((el as HTMLSelectElement).options).map((opt) => {
+            const style = getComputedStyle(opt);
+            return {
+              backgroundColor: style.backgroundColor,
+              color: style.color,
+            };
+          }),
         );
-        expect(
-          backgroundColor,
-          `${label} select background must differ from its text color`,
-        ).not.toBe(color);
+
+        expect(options.length, `${label} should have options`).toBeGreaterThan(
+          0,
+        );
+        for (const { backgroundColor, color } of options) {
+          expect(backgroundColor, `${label} option background`).not.toBe(
+            "rgba(0, 0, 0, 0)",
+          );
+          expect(
+            backgroundColor,
+            `${label} option background must differ from its text color`,
+          ).not.toBe(color);
+        }
       }
     });
   });

--- a/tests/regression/select-dropdown-regression.spec.ts
+++ b/tests/regression/select-dropdown-regression.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "@playwright/test";
+import { AUTH_STATE_PATH } from "../global-setup";
+import { resetDatabase } from "../reset-db";
+import { themes, setTheme } from "./theme-utils";
+
+test.use({ storageState: AUTH_STATE_PATH });
+test.beforeEach(resetDatabase);
+
+/*
+ * Regression test for: native <select> popups rendering unreadable
+ * (e.g. white-on-white) in Chrome on Windows when both the OS and the site
+ * are in dark mode.
+ *
+ * Chromium keys the native option-list popup's colors off `color-scheme`,
+ * but only if the <select> itself resolves to a real, non-transparent
+ * background/text color — a `background-color: transparent` select gives
+ * Chromium nothing to match the popup to, so it falls back to UA defaults
+ * that can conflict with the inherited (theme) text color.
+ *
+ * The popup itself is a native OS/browser widget, not part of the page's
+ * render tree, so it can't be captured with page.screenshot() (confirmed:
+ * clicking/opening a <select> never appears in a Playwright screenshot,
+ * even headless on Linux). So instead we assert directly on the computed
+ * style responsible for the bug.
+ */
+for (const theme of themes) {
+  test.describe(`select dropdown colors (${theme})`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/profile");
+      await page.waitForLoadState("networkidle");
+      await setTheme(page, theme);
+    });
+
+    test("State and Congressional District selects have an opaque, theme-matched background", async ({
+      page,
+    }) => {
+      for (const label of ["State", "Congressional District"]) {
+        const select = page.getByLabel(label);
+        const { backgroundColor, color } = await select.evaluate((el) => {
+          const style = getComputedStyle(el);
+          return { backgroundColor: style.backgroundColor, color: style.color };
+        });
+
+        expect(backgroundColor, `${label} select background`).not.toBe(
+          "rgba(0, 0, 0, 0)",
+        );
+        expect(
+          backgroundColor,
+          `${label} select background must differ from its text color`,
+        ).not.toBe(color);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Native `<select>` dropdowns showed their options as white-on-white in dark mode, but only in Chromium-based browsers on Windows. Firefox was fine, and light mode was fine.

Windows Chromium draws the option-list popup with an OS-native menu that doesn't honor `color-scheme` for the option rows. Since the select's text is forced to the light foreground color and the options had no explicit background of their own, the rows fell back to the native light menu background.

The shared `Select` now sets an explicit background and text color on its `<option>` elements from the semantic theme tokens, so they stay readable in every theme. All native selects in the app go through this component, so it's a single fix.

<img width="552" height="835" alt="image" src="https://github.com/user-attachments/assets/9f494b5e-a1bf-43a1-aafd-7f5fb24ba77c" />
