### PR TITLE
Fix redirect loop between login, sign-up, and home

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
+import { getCurrentUser } from "@/lib/auth/role";
 import { SuspenseWithDefaultFallback } from "@/components/suspense-with-default-fallback";
 import { BetaBanner } from "@/components/homepage/beta-banner";
 import { ResourceLinks } from "@/components/homepage/resource-links";
@@ -8,10 +8,9 @@ import { ResourceLinks } from "@/components/homepage/resource-links";
 export const metadata: Metadata = { title: "Home" };
 
 async function HomeContent() {
-  const supabase = await createClient();
-  const { data, error } = await supabase.auth.getUser();
+  const user = await getCurrentUser();
 
-  if (error || !data?.user) {
+  if (!user) {
     redirect("/auth/login");
   }
 

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
-import { getCurrentRole, type CurrentRole } from "./role";
-import { createClient } from "@/lib/supabase/server";
+import { getCurrentRole, getCurrentUser, type CurrentRole } from "./role";
 
 export class ForbiddenError extends Error {
   constructor(message = "Forbidden") {
@@ -47,7 +46,6 @@ export async function getIsAdmin(orgId: string): Promise<boolean> {
  * forgot-password, etc).
  */
 export async function requireGuest(): Promise<void> {
-  const supabase = await createClient();
-  const { data } = await supabase.auth.getUser();
-  if (data?.user) redirect("/");
+  const user = await getCurrentUser();
+  if (user) redirect("/");
 }

--- a/lib/auth/role.ts
+++ b/lib/auth/role.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/lib/supabase/database.types";
+import type { User } from "@supabase/supabase-js";
 
 export type UserRole = Database["public"]["Enums"]["app_role"];
 
@@ -10,13 +11,21 @@ export type CurrentRole = {
   org_id: string | null;
 };
 
-export const getCurrentRole = cache(async (): Promise<CurrentRole | null> => {
+// Cached per-request so repeated calls (page + guards) don't each hit
+// Supabase's Auth API and race on session refresh.
+export const getCurrentUser = cache(async (): Promise<User | null> => {
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  return user;
+});
+
+export const getCurrentRole = cache(async (): Promise<CurrentRole | null> => {
+  const user = await getCurrentUser();
   if (!user) return null;
 
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("user_role")
     .select("user_id, role, org_id")


### PR DESCRIPTION
## Summary
- A user got stuck in an infinite redirect loop between `/`, `/auth/login`, and `/auth/sign-up` right after logging in, even though her login succeeded and her session was valid.
- Root cause: the home page, `requireGuest`, and `getCurrentRole` each independently called `supabase.auth.getUser()`. Each call can trigger its own session refresh, and two of these refreshes racing over the same rotating refresh token could make one call falsely report "no user" while another, moments later, correctly found one.
- This is a related but separate issue from #294, which removed `requireGuest()` from the login and forgot-password pages. That patched two of the three redirect loop's guard call sites but not the underlying race, so the loop just re-opened through `/auth/sign-up` instead.
- Fix: route all three call sites through one `cache()`-wrapped `getCurrentUser()` so a single request only validates the session once, removing the race.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint` passes on changed files
- [ ] Manually verify: log in, confirm no redirect loop; visit `/auth/sign-up` while logged in, confirm redirect to `/`; visit `/` while logged out, confirm redirect to `/auth/login`