### PR TITLE
Show scrollbars on overflow and fix auth page spacing

### DIFF
--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -34,23 +34,19 @@ export default async function Page({
 }) {
   await requireGuest();
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
-      <div className="w-full max-w-sm">
-        <div className="flex flex-col gap-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-2xl">
-                Sorry, something went wrong.
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Suspense>
-                <ErrorContent searchParams={searchParams} />
-              </Suspense>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl">
+            Sorry, something went wrong.
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Suspense>
+            <ErrorContent searchParams={searchParams} />
+          </Suspense>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/app/auth/sign-up-success/page.tsx
+++ b/app/auth/sign-up-success/page.tsx
@@ -16,30 +16,24 @@ export const metadata: Metadata = { title: "Check Your Email" };
 export default async function Page() {
   await requireGuest();
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
-      <div className="w-full max-w-sm">
-        <div className="flex flex-col gap-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-2xl">
-                Thank you for signing up!
-              </CardTitle>
-              <CardDescription>Check your email to confirm</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-muted-foreground">
-                You&apos;ve successfully signed up. Please check your email to
-                confirm your account before signing in.
-              </p>
-            </CardContent>
-            <CardFooter>
-              <Button asChild className="w-full">
-                <Link href="/auth/login">Back to login</Link>
-              </Button>
-            </CardFooter>
-          </Card>
-        </div>
-      </div>
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl">Thank you for signing up!</CardTitle>
+          <CardDescription>Check your email to confirm</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            You&apos;ve successfully signed up. Please check your email to
+            confirm your account before signing in.
+          </p>
+        </CardContent>
+        <CardFooter>
+          <Button asChild className="w-full">
+            <Link href="/auth/login">Back to login</Link>
+          </Button>
+        </CardFooter>
+      </Card>
     </div>
   );
 }

--- a/app/auth/update-password/page.tsx
+++ b/app/auth/update-password/page.tsx
@@ -4,11 +4,5 @@ import { UpdatePasswordForm } from "@/components/update-password-form";
 export const metadata: Metadata = { title: "Update Password" };
 
 export default function Page() {
-  return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
-      <div className="w-full max-w-sm">
-        <UpdatePasswordForm />
-      </div>
-    </div>
-  );
+  return <UpdatePasswordForm />;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -176,6 +176,40 @@
 }
 
 /*
+ * Safari, and Chrome on macOS, use overlay scrollbars that stay invisible until
+ * you scroll, so a container that overflows (a wide table, say) just looks like
+ * its content ends early. Styling the scrollbar opts every scrollable element
+ * into a classic always-drawn bar, which the browser only reserves space for
+ * when the content really does overflow.
+ *
+ * These have to be the `-webkit-` pseudo-elements rather than the standard
+ * `scrollbar-width`/`scrollbar-color`: Chromium ignores the pseudo-elements as
+ * soon as either standard property is set, and its `thin` keyword still renders
+ * the full-width native bar. Firefox keeps its native scrollbars either way.
+ */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  background-color: hsl(var(--border));
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground));
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/*
  * High-contrast theme: decorative accents (table headers, party/type badges,
  * status icons) use fixed Tailwind palette colors that ignore the semantic
  * theme tokens, so they stay colorful in high-contrast mode. Force them to

--- a/app/globals.css
+++ b/app/globals.css
@@ -175,18 +175,7 @@
   }
 }
 
-/*
- * Safari, and Chrome on macOS, use overlay scrollbars that stay invisible until
- * you scroll, so a container that overflows (a wide table, say) just looks like
- * its content ends early. Styling the scrollbar opts every scrollable element
- * into a classic always-drawn bar, which the browser only reserves space for
- * when the content really does overflow.
- *
- * These have to be the `-webkit-` pseudo-elements rather than the standard
- * `scrollbar-width`/`scrollbar-color`: Chromium ignores the pseudo-elements as
- * soon as either standard property is set, and its `thin` keyword still renders
- * the full-width native bar. Firefox keeps its native scrollbars either way.
- */
+/* Force always-visible scrollbars over macOS overlay ones; must be `-webkit-` pseudo-elements, since Chromium drops them if `scrollbar-width`/`scrollbar-color` is set. */
 ::-webkit-scrollbar {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
Two fixes regarding UI

## Scrollbars

On the team edit page the members table can outgrow its column. At 1024px it needs 522px but gets 498px, so the remove and delete buttons scroll out of sight. Safari and Chrome on macOS use overlay scrollbars that stay invisible until you scroll, so the table just looks like it ends early, with nothing to suggest there's more to the right.

Styling `::-webkit-scrollbar` opts scrollable elements into a classic always-drawn bar. The browser only reserves space for it when content actually overflows, so containers that fit are unaffected.

This has to use the `-webkit-` pseudo-elements rather than the standard `scrollbar-width`/`scrollbar-color`. Chromium discards the pseudo-element rules as soon as either standard property is set, and its `thin` keyword still renders a full-width native bar. Firefox keeps its native scrollbars either way.

## Auth page spacing

`update-password`, `error`, and `sign-up-success` each wrapped their card in `flex min-h-svh items-center justify-center`, but `app/auth/layout.tsx` already does that. Two stacked `min-h-svh` blocks pushed the card a full viewport below the logo, which was most obvious on the reset password form. Removing the duplicate wrappers makes all three match `login`, `sign-up`, and `forgot-password`, which just return their form.
