### PR TITLE
Fix bug where some meetings were duplicated

### DIFF
--- a/lib/meetings/queries.ts
+++ b/lib/meetings/queries.ts
@@ -145,7 +145,8 @@ export async function fetchMeetings(
       count: "exact",
     })
     .order("meeting_date", { ascending })
-    .order("meeting_time", { ascending });
+    .order("meeting_time", { ascending })
+    .order("id", { ascending });
 
   if (section === "upcoming") {
     query = query.gte("meeting_date", today);


### PR DESCRIPTION
Some meetings were duplicated, this was because we had a bunch of meetings right at the pagination boundary at the exact same date and time. The query for meetings did not have a tie-breaker so it would silently duplicate one and drop the other.

This fixes by adding ID as a tie-breaker.